### PR TITLE
fix: [TKC-1215] worker service use service monitor

### DIFF
--- a/charts/testkube-workers-service/templates/service.yaml
+++ b/charts/testkube-workers-service/templates/service.yaml
@@ -1,0 +1,24 @@
+{{- if .Values.prometheus.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "testkube-worker-service.fullname" . }}
+  labels:
+    {{- include "testkube-worker-service.labels" . | nindent 4 }}
+    {{- with .Values.service.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- with .Values.service.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.metricsPort }}
+      targetPort: metrics
+      protocol: TCP
+      name: metrics
+  selector:
+    {{- include "testkube-worker-service.selectorLabels" . | nindent 4 }}
+{{- end }}

--- a/charts/testkube-workers-service/templates/servicemonitor.yaml
+++ b/charts/testkube-workers-service/templates/servicemonitor.yaml
@@ -1,6 +1,6 @@
 {{- if .Values.prometheus.enabled }}
 apiVersion: monitoring.coreos.com/v1
-kind: PodMonitor
+kind: ServiceMonitor
 metadata:
   name: {{ include "testkube-worker-service.fullname" . }}
   namespace: {{ .Release.Namespace }}
@@ -13,7 +13,7 @@ spec:
   selector:
     matchLabels:
       {{- include "testkube-worker-service.selectorLabels" . | nindent 6 }}
-  podMetricsEndpoints:
+  endpoints:
     - port: {{ .Values.prometheus.port }}
       path: {{ .Values.prometheus.path }}
       interval: {{ .Values.prometheus.scrapeInterval }}

--- a/charts/testkube-workers-service/values.yaml
+++ b/charts/testkube-workers-service/values.yaml
@@ -78,6 +78,16 @@ autoscaling:
   targetCPUUtilizationPercentage: 80
   targetMemoryUtilizationPercentage: 80
 
+service:
+  # -- Service type
+  type: ClusterIP
+  # -- Additional annotations to add to the Service resource
+  annotations: {}
+  # -- Additional labels to add to the Service resource
+  labels: {}
+  # -- Metrics port
+  metricsPort: 9000
+
 prometheus:
   # -- Toggle whether to create ServiceMonitor resource for Prometheus Operator
   enabled: false


### PR DESCRIPTION
Checklist:

* [ ] Any new values are backwards compatible and/or have sensible default.
* [ ] I have signed off all my commits as required by [DCO](https://github.com/kubeshop/testkube-cloud-charts/blob/master/community/CONTRIBUTING.md).
* [ ] My CI is green.

<!-- Changes are automatically published when merged to `main`. They are not published on branches. -->