### PR TITLE
fix: enteprise valid logs port number

### DIFF
--- a/charts/testkube-enterprise/values.yaml
+++ b/charts/testkube-enterprise/values.yaml
@@ -145,7 +145,7 @@ testkube-cloud-api:
     # -- External log server connection configuration
     logServer:
       # -- Log server address
-      grpcAddress: "testkube-enterprise-logs-service:8090"
+      grpcAddress: "testkube-enterprise-logs-service:8089"
       # -- Log server TLS configuration secure connection
       secure: "false"
       # -- Log server TLS configuration skip Verify


### PR DESCRIPTION
Checklist:

* [x] Any new values are backwards compatible and/or have sensible default.
* [ ] I have signed off all my commits as required by [DCO](https://github.com/kubeshop/testkube-cloud-charts/blob/master/community/CONTRIBUTING.md).
* [ ] My CI is green.

<!-- Changes are automatically published when merged to `main`. They are not published on branches. -->