### PR TITLE
fix: use default grpc port

### DIFF
--- a/charts/testkube-cloud-api/values.yaml
+++ b/charts/testkube-cloud-api/values.yaml
@@ -220,7 +220,7 @@ api:
     # -- Toggle whether to enable external log server connection
     enabled: false
     # -- Log server address for internal communication
-    grpcAddress: "testkube-logs-service:8090"
+    grpcAddress: "testkube-logs-service:8089"
     # -- Log server TLS configuration secure connection
     secure: "false"
     # -- Log server TLS configuration skip Verify

--- a/charts/testkube-enterprise/local-values.yaml
+++ b/charts/testkube-enterprise/local-values.yaml
@@ -147,7 +147,7 @@ testkube-cloud-api:
       # -- Toggle whether to enable log server connection
       enabled: false
       # -- Log server address
-      grpcAddress: "testkube-enterprise-logs-service:8090"
+      grpcAddress: "testkube-enterprise-logs-service:8089"
       # -- Log server TLS configuration secure connection
       secure: "false"
       # -- Log server TLS configuration skip Verify


### PR DESCRIPTION
Checklist:

* [ ] Any new values are backwards compatible and/or have sensible default.
* [ ] I have signed off all my commits as required by [DCO](https://github.com/kubeshop/testkube-cloud-charts/blob/master/community/CONTRIBUTING.md).
* [ ] My CI is green.

<!-- Changes are automatically published when merged to `main`. They are not published on branches. -->