### PR TITLE
feat: inject custom ca into the enterprise api

### DIFF
--- a/charts/testkube-cloud-api/templates/deployment.yaml
+++ b/charts/testkube-cloud-api/templates/deployment.yaml
@@ -262,6 +262,10 @@ spec:
               value: "{{ .Values.api.tls.certPath }}"
             - name: TLS_KEY
               value: "{{ .Values.api.tls.keyPath }}"
+            {{- if .Values.global.customCaSecretRef }}
+            - name: SSL_CERT_DIR
+              value: /etc/testkube/certs
+            {{- end }}
             - name: OUTPUTS_BUCKET
               value: "{{ .Values.api.outputsBucket }}"
             - name: MINIO_ENDPOINT
@@ -348,7 +352,7 @@ spec:
               port: {{ if .Values.api.tls.serveHTTPS }}https{{ else }}http{{ end }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
-          {{- if or .Values.api.tls.serveHTTPS .Values.global.enterpriseLicenseSecretRef }}
+          {{- if or .Values.api.tls.serveHTTPS .Values.global.enterpriseLicenseSecretRef .Values.global.customCaSecretRef }}
           volumeMounts:
             {{- if .Values.api.tls.serveHTTPS }}
             - mountPath: /tmp/serving-cert/crt.pem
@@ -366,6 +370,12 @@ spec:
               name: license-file
               subPath: license.lic
             {{- end }}
+            {{- if .Values.global.customCaSecretRef }}
+            - mountPath: /etc/testkube/certs/testkube-custom-ca.pem
+              name: {{ .Values.global.customCaSecretRef }}
+              readOnly: true
+              subPath: ca.crt
+            {{- end }}
           {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
@@ -379,7 +389,7 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- if or .Values.api.tls.serveHTTPS .Values.global.enterpriseLicenseSecretRef }}
+      {{- if or .Values.api.tls.serveHTTPS .Values.global.enterpriseLicenseSecretRef .Values.global.customCaSecretRef }}
       volumes:
         {{- if .Values.api.tls.serveHTTPS }}
         - name: serving-cert
@@ -390,5 +400,11 @@ spec:
         - name: license-file
           secret:
             secretName: {{ .Values.global.enterpriseLicenseSecretRef }}
+        {{- end }}
+        {{- if .Values.global.customCaSecretRef }}
+        - name: {{ .Values.global.customCaSecretRef }}
+          secret:
+            secretName: {{ .Values.global.customCaSecretRef }}
+            defaultMode: 420
         {{- end }}
       {{- end }}

--- a/charts/testkube-cloud-api/values.yaml
+++ b/charts/testkube-cloud-api/values.yaml
@@ -30,6 +30,8 @@ global:
   certManager:
     # -- Certificate Issuer ref (only used if `provider` is set to `cert-manager`)
     issuerRef: ""
+  # -- Custom CA to use as a trusted CA during TLS connections. Specify a secret with the PEM encoded CA under the ca.crt key.
+  customCaSecretRef: ""
   # -- Global image pull secrets (provided usually by a parent chart like testkube-enterprise)
   imagePullSecrets: []
   ingress:

--- a/charts/testkube-enterprise/values.yaml
+++ b/charts/testkube-enterprise/values.yaml
@@ -34,6 +34,8 @@ global:
   certManager:
     # -- Certificate Issuer ref (only used if `provider` is set to `cert-manager`)
     issuerRef: ""
+  # -- Custom CA to use as a trusted CA during TLS connections. Specify a secret with the PEM encoded CA under the ca.crt key.
+  customCaSecretRef: ""
   # -- Image pull secrets to use for testkube-cloud-api and testkube-cloud-ui
   imagePullSecrets: []
   ingress:


### PR DESCRIPTION
Checklist:

* [ ] Any new values are backwards compatible and/or have sensible default.
* [ ] I have signed off all my commits as required by [DCO](https://github.com/kubeshop/testkube-cloud-charts/blob/master/community/CONTRIBUTING.md).
* [ ] My CI is green.

<!-- Changes are automatically published when merged to `main`. They are not published on branches. -->