### PR TITLE
feat: add support for readpref and agent storage host overrides

### DIFF
--- a/charts/testkube-cloud-api/templates/deployment.yaml
+++ b/charts/testkube-cloud-api/templates/deployment.yaml
@@ -182,6 +182,8 @@ spec:
               {{- end }}
             - name: API_MONGO_DB
               value: {{ .Values.api.mongo.database }}
+            - name: API_MONGO_READ_PREFERENCE
+              value: {{ .Values.api.mongo.readPreference }}
               {{- if .Values.api.oauth.secretRef }}
             - name: OAUTH_CLIENT_ID
               valueFrom:
@@ -323,6 +325,10 @@ spec:
               value: "{{ .Values.api.logServer.caFile }}"
             - name: "MINIO_SKIP_VERIFY"
               value: "{{ .Values.api.minio.skipVerify }}"
+            - name: "AGENT_STORAGE_HOSTNAME"
+              value: "{{ .Values.api.minio.signing.hostname }}"
+            - name: "AGENT_STORAGE_SSL"
+              value: "{{ .Values.api.minio.signing.secure }}"
             {{- if .Values.api.minio.certSecret.enabled }}
             - name: "MINIO_CERT_FILE"
               value: "{{ .Values.api.minio.certSecret.baseMountPath }}/{{ .Values.api.minio.certSecret.certFile }}"

--- a/charts/testkube-cloud-api/values.yaml
+++ b/charts/testkube-cloud-api/values.yaml
@@ -148,6 +148,8 @@ api:
     dsn: "mongodb://mongodb.testkube.svc.cluster.local:27017"
     # -- Mongo database name
     database: "testkubecloud"
+    # -- Mongo read preference (primary|primaryPreferred|secondary|secondaryPreferred|nearest)
+    readPreference: secondaryPreferred
   nats:
     # -- NATS URI
     uri: "nats://nats.messaging.svc.cluster.local:4222"
@@ -172,6 +174,12 @@ api:
     skipVerify: false
     # -- If enabled, will also require a CA certificate to be provided
     mountCACertificate: false
+    # Configure this if you want a different hostname for the presigned PUT URL (used by Agents to upload artifacts)
+    signing:
+      # -- Hostname for the presigned PUT URL
+      hostname: ""
+      # -- Toggle should the presigned URL use HTTPS
+      secure: false
     certSecret:
       # -- Toggle whether to mount k8s secret which contains storage client certificate (cert.crt, cert.key, ca.crt)
       enabled: false

--- a/charts/testkube-enterprise/values.yaml
+++ b/charts/testkube-enterprise/values.yaml
@@ -193,6 +193,8 @@ testkube-cloud-api:
       dsn: "mongodb://testkube-enterprise-mongodb:27017"
       # -- Mongo database name
       database: "testkubeEnterpriseDB"
+      # -- Mongo read preference (primary|primaryPreferred|secondary|secondaryPreferred|nearest)
+      readPreference: secondaryPreferred
     nats:
       # -- NATS URI
       uri: "nats://testkube-enterprise-nats:4222"
@@ -217,6 +219,12 @@ testkube-cloud-api:
       skipVerify: false
       # -- If enabled, will also require a CA certificate to be provided
       mountCACertificate: false
+      # Configure this if you want a different hostname for the presigned PUT URL (used by Agents to upload artifacts)
+      signing:
+        # -- Hostname for the presigned PUT URL
+        hostname: ""
+        # -- Toggle should the presigned URL use HTTPS
+        secure: false
       certSecret:
         # -- Toggle whether to mount k8s secret which contains storage client certificate (cert.crt, cert.key, ca.crt)
         enabled: false


### PR DESCRIPTION
Checklist:

* [ ] Any new values are backwards compatible and/or have sensible default.
* [ ] I have signed off all my commits as required by [DCO](https://github.com/kubeshop/testkube-cloud-charts/blob/master/community/CONTRIBUTING.md).
* [ ] My CI is green.

<!-- Changes are automatically published when merged to `main`. They are not published on branches. -->