### PR TITLE
fix: improve docs for offline license and deprecate ineffective enterpriseLicenseFile field

### DIFF
--- a/charts/testkube-cloud-api/values.yaml
+++ b/charts/testkube-cloud-api/values.yaml
@@ -7,11 +7,11 @@ global:
   enterpriseMode: false
   # -- Toggle whether to enable offline license activation in Enterprise mode
   enterpriseOfflineAccess: false
-  # -- Enterprise License key
+  # -- Specifies the enterprise license key, when using an offline license use `enterpriseLicenseSecretRef` and leave this field empty.
   enterpriseLicenseKey: ""
-  # -- Base64-encoded Enterprise License file
+  # -- This field is deprecated. To specify an offline license file use `enterpriseLicenseSecretRef`.
   enterpriseLicenseFile: ""
-  # -- Enterprise License file secret reference. Place the license key under the key `LICENSE_KEY` key in the secret, and in case of an offline license place the license file under the key `license.lic` in the same secret. Make sure that the license key file does not have any new line characters at the end of the file.
+  # -- Enterprise license file secret reference. Place the license key under the key `LICENSE_KEY` key in the secret, and in case of an offline license place the license file under the key `license.lic` in the same secret. Make sure that the license key file does not have any new line characters at the end of the file.
   enterpriseLicenseSecretRef: ""
   # -- Domain under which to create Ingress rules
   domain: ""

--- a/charts/testkube-cloud-api/values.yaml
+++ b/charts/testkube-cloud-api/values.yaml
@@ -11,7 +11,7 @@ global:
   enterpriseLicenseKey: ""
   # -- Base64-encoded Enterprise License file
   enterpriseLicenseFile: ""
-  # -- Enterprise License file secret ref (secret should contain a file called 'license.lic')
+  # -- Enterprise License file secret reference. Place the license key under the key `LICENSE_KEY` key in the secret, and in case of an offline license place the license file under the key `license.lic` in the same secret. Make sure that the license key file does not have any new line characters at the end of the file.
   enterpriseLicenseSecretRef: ""
   # -- Domain under which to create Ingress rules
   domain: ""

--- a/charts/testkube-enterprise/local-values.yaml
+++ b/charts/testkube-enterprise/local-values.yaml
@@ -5,14 +5,14 @@
 global:
   # -- Run Testkube in enterprise mode (enables enterprise features)
   enterpriseMode: true
+  # -- Toggle whether to enable offline license activation in Enterprise mode
+  enterpriseOfflineAccess: false
   # -- Enterprise License key
   enterpriseLicenseKey: ""
   # -- Base64-encoded Enterprise License file
   enterpriseLicenseFile: ""
-  # -- Enterprise License file secret ref (secret should contain a file called 'license.lic')
+  # -- Enterprise License file secret reference. Place the license key under the key `LICENSE_KEY` key in the secret, and in case of an offline license place the license file under the key `license.lic` in the same secret. Make sure that the license key file does not have any new line characters at the end of the file.
   enterpriseLicenseSecretRef: "testkube-enterprise-license"
-  # -- Toggle whether to enable offline license activation in Enterprise mode
-  enterpriseOfflineAccess: false
   # -- Domain under which to create Ingress rules
   domain: ""
   # -- UI subdomain which get prepended to the domain

--- a/charts/testkube-enterprise/local-values.yaml
+++ b/charts/testkube-enterprise/local-values.yaml
@@ -7,11 +7,11 @@ global:
   enterpriseMode: true
   # -- Toggle whether to enable offline license activation in Enterprise mode
   enterpriseOfflineAccess: false
-  # -- Enterprise License key
+  # -- Specifies the enterprise license key, when using an offline license use `enterpriseLicenseSecretRef` and leave this field empty.
   enterpriseLicenseKey: ""
-  # -- Base64-encoded Enterprise License file
+  # -- This field is deprecated. To specify an offline license file use `enterpriseLicenseSecretRef`.
   enterpriseLicenseFile: ""
-  # -- Enterprise License file secret reference. Place the license key under the key `LICENSE_KEY` key in the secret, and in case of an offline license place the license file under the key `license.lic` in the same secret. Make sure that the license key file does not have any new line characters at the end of the file.
+  # -- Enterprise license file secret reference. Place the license key under the key `LICENSE_KEY` key in the secret, and in case of an offline license place the license file under the key `license.lic` in the same secret. Make sure that the license key file does not have any new line characters at the end of the file.
   enterpriseLicenseSecretRef: "testkube-enterprise-license"
   # -- Domain under which to create Ingress rules
   domain: ""

--- a/charts/testkube-enterprise/values.yaml
+++ b/charts/testkube-enterprise/values.yaml
@@ -5,14 +5,14 @@
 global:
   # -- Run Testkube in enterprise mode (enables enterprise features)
   enterpriseMode: true
+  # -- Toggle whether to enable offline license activation in Enterprise mode
+  enterpriseOfflineAccess: false
   # -- Enterprise License key
   enterpriseLicenseKey: ""
   # -- Base64-encoded Enterprise License file
   enterpriseLicenseFile: ""
-  # -- Enterprise License file secret ref (secret should contain a file called 'license.lic')
+  # -- Enterprise License file secret reference. Place the license key under the key `LICENSE_KEY` key in the secret, and in case of an offline license place the license file under the key `license.lic` in the same secret. Make sure that the license key file does not have any new line characters at the end of the file.
   enterpriseLicenseSecretRef: ""
-  # -- Toggle whether to enable offline license activation in Enterprise mode
-  enterpriseOfflineAccess: false
   # -- Domain under which to create Ingress rules
   domain: ""
   # -- UI subdomain which get prepended to the domain

--- a/charts/testkube-enterprise/values.yaml
+++ b/charts/testkube-enterprise/values.yaml
@@ -7,11 +7,11 @@ global:
   enterpriseMode: true
   # -- Toggle whether to enable offline license activation in Enterprise mode
   enterpriseOfflineAccess: false
-  # -- Enterprise License key
+  # -- Specifies the enterprise license key, when using an offline license use `enterpriseLicenseSecretRef` and leave this field empty.
   enterpriseLicenseKey: ""
-  # -- Base64-encoded Enterprise License file
+  # -- This field is deprecated. To specify an offline license file use `enterpriseLicenseSecretRef`.
   enterpriseLicenseFile: ""
-  # -- Enterprise License file secret reference. Place the license key under the key `LICENSE_KEY` key in the secret, and in case of an offline license place the license file under the key `license.lic` in the same secret. Make sure that the license key file does not have any new line characters at the end of the file.
+  # -- Enterprise license file secret reference. Place the license key under the key `LICENSE_KEY` key in the secret, and in case of an offline license place the license file under the key `license.lic` in the same secret. Make sure that the license key file does not have any new line characters at the end of the file.
   enterpriseLicenseSecretRef: ""
   # -- Domain under which to create Ingress rules
   domain: ""


### PR DESCRIPTION
Cherry-pick of #139 back to `develop`.

Checklist:

* [ ] Any new values are backwards compatible and/or have sensible default.
* [ ] I have signed off all my commits as required by [DCO](https://github.com/kubeshop/testkube-cloud-charts/blob/master/community/CONTRIBUTING.md).
* [ ] My CI is green.

<!-- Changes are automatically published when merged to `main`. They are not published on branches. -->