### PR TITLE
fix: image registry override

### DIFF
--- a/charts/testkube-cloud-api/templates/_helpers.tpl
+++ b/charts/testkube-cloud-api/templates/_helpers.tpl
@@ -115,7 +115,7 @@ Define API image
 {{- define "testkube-api.image" -}}
 {{- $registryName := default "docker.io" .Values.image.registry -}}
 {{- $repositoryName := .Values.image.repository -}}
-{{- $tag := default .Chart.AppVersion .Values.image.tag | toString -}}
+{{- $tag := default .Values.image.tag .Chart.AppVersion | toString -}}
 {{- $separator := ":" -}}
 {{- if .Values.image.digest }}
     {{- $separator = "@" -}}

--- a/charts/testkube-cloud-api/templates/_helpers.tpl
+++ b/charts/testkube-cloud-api/templates/_helpers.tpl
@@ -110,6 +110,29 @@ Get Websockets Ingress host
 {{- end }}
 
 {{/*
+Define API image
+*/}}
+{{- define "testkube-api.image" -}}
+{{- $registryName := default "docker.io" .Values.image.registry -}}
+{{- $repositoryName := .Values.image.repository -}}
+{{- $tag := default .Chart.AppVersion .Values.image.tag | toString -}}
+{{- $separator := ":" -}}
+{{- if .Values.image.digest }}
+    {{- $separator = "@" -}}
+    {{- $tag = .Values.image.digest | toString -}}
+{{- end -}}
+{{- if .Values.global }}
+    {{- if .Values.global.imageRegistry }}
+        {{- printf "%s/%s%s%s" .Values.global.imageRegistry $repositoryName $separator $tag -}}
+    {{- else -}}
+        {{- printf "%s/%s%s%s" $registryName $repositoryName $separator $tag -}}
+    {{- end -}}
+{{- else -}}
+    {{- printf "%s/%s%s%s" $registryName $repositoryName $separator $tag -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
 THIS IS A HACK TO WORKAROUND LET'S ENCRYPT RATE LIMITS
 */}}
 {{- define "testkube-cloud-api.ingress.hackHost" -}}

--- a/charts/testkube-cloud-api/templates/bootstrap-config.yaml
+++ b/charts/testkube-cloud-api/templates/bootstrap-config.yaml
@@ -24,28 +24,28 @@ data:
     default_organizations:
       - {{ .Values.api.features.bootstrapOrg }}
     organizations:
-      - name: {{ .Values.api.features.bootstrapOrg }}
-        {{- if .Values.api.features.bootstrapAdmin }}
-        default_role: admin
-        members:
-          - email: {{.Values.api.features.bootstrapAdmin}}
-            role: admin
-        {{- end }}
+      - name: {{ .Values.api.features.bootstrapOrg }}        
         {{- if .Values.api.features.bootstrapEnv }}
         default_environments:
           - {{.Values.api.features.bootstrapEnv}}
         environments:
           - name: {{.Values.api.features.bootstrapEnv}}
-            {{- if .Values.api.features.bootstrapAdmin }}
-            default_role: admin
-            members:
-              - email: {{.Values.api.features.bootstrapAdmin}}
-                role: admin
-            {{- end }}
             {{- if .Values.api.features.bootstrapAgentTokenSecretRef }}
             agentToken:
               valueFrom:
                 envRef: {{ snakecase .Values.api.features.bootstrapAgentTokenSecretRef | upper | quote }}
             {{- end }}
+            default_role: admin
+            {{- if .Values.api.features.bootstrapAdmin }}
+            members:
+              - email: {{.Values.api.features.bootstrapAdmin}}
+                role: admin
+            {{- end }}
+        {{- end }}
+        default_role: admin
+        {{- if .Values.api.features.bootstrapAdmin }}
+        members:
+          - email: {{.Values.api.features.bootstrapAdmin}}
+            role: admin
         {{- end }}
 {{- end }}

--- a/charts/testkube-cloud-api/templates/deployment.yaml
+++ b/charts/testkube-cloud-api/templates/deployment.yaml
@@ -34,8 +34,8 @@ spec:
         - name: {{ .Chart.Name }}
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
-          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
-          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          image: {{ include "testkube-api.image" . }}
+          imagePullPolicy: {{ .Values.global.imagePullPolicy | default .Values.image.pullPolicy }}
           env:
             - name: DEMO_ORGANIZATION_ID
               value: "{{ .Values.demoOrganizationId }}"

--- a/charts/testkube-cloud-ui/templates/_helpers.tpl
+++ b/charts/testkube-cloud-ui/templates/_helpers.tpl
@@ -77,7 +77,7 @@ Define image
 {{- define "testkube-dashboard.image" -}}
 {{- $registryName := default "docker.io" .Values.image.registry -}}
 {{- $repositoryName := .Values.image.repository -}}
-{{- $tag := default .Chart.AppVersion .Values.image.tag | toString -}}
+{{- $tag := default .Values.image.tag .Chart.AppVersion | toString -}}
 {{- $separator := ":" -}}
 {{- if .Values.image.digest }}
     {{- $separator = "@" -}}

--- a/charts/testkube-cloud-ui/templates/_helpers.tpl
+++ b/charts/testkube-cloud-ui/templates/_helpers.tpl
@@ -70,3 +70,26 @@ Get Ingress host
 {{- printf "%s.%s" .Values.global.uiSubdomain .Values.global.domain }}
 {{- end }}
 {{- end }}
+
+{{/*
+Define image
+*/}}
+{{- define "testkube-dashboard.image" -}}
+{{- $registryName := default "docker.io" .Values.image.registry -}}
+{{- $repositoryName := .Values.image.repository -}}
+{{- $tag := default .Chart.AppVersion .Values.image.tag | toString -}}
+{{- $separator := ":" -}}
+{{- if .Values.image.digest }}
+    {{- $separator = "@" -}}
+    {{- $tag = .Values.image.digest | toString -}}
+{{- end -}}
+{{- if .Values.global }}
+    {{- if .Values.global.imageRegistry }}
+        {{- printf "%s/%s%s%s" .Values.global.imageRegistry $repositoryName $separator $tag -}}
+    {{- else -}}
+        {{- printf "%s/%s%s%s" $registryName $repositoryName $separator $tag -}}
+    {{- end -}}
+{{- else -}}
+    {{- printf "%s/%s%s%s" $registryName $repositoryName $separator $tag -}}
+{{- end -}}
+{{- end -}}

--- a/charts/testkube-cloud-ui/templates/deployment.yaml
+++ b/charts/testkube-cloud-ui/templates/deployment.yaml
@@ -34,8 +34,8 @@ spec:
         - name: {{ .Chart.Name }}
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
-          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
-          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          image: {{ include "testkube-dashboard.image" . }}
+          imagePullPolicy: {{ .Values.global.imagePullPolicy | default .Values.image.pullPolicy }}
           ports:
             - name: http
               containerPort: 8080

--- a/charts/testkube-enterprise/profiles/values.demo.yaml
+++ b/charts/testkube-enterprise/profiles/values.demo.yaml
@@ -17,8 +17,7 @@ sharedSecretGenerator:
   enabled: true
   securityContext: {}
   resources: {}
-  ## Optional settings
-  # image:
+  image: {}
 
 testkube-cloud-api:
   fullnameOverride: testkube-enterprise-api

--- a/charts/testkube-enterprise/profiles/values.demo.yaml
+++ b/charts/testkube-enterprise/profiles/values.demo.yaml
@@ -35,13 +35,12 @@ testkube-cloud-api:
     OAUTH_JWKS_URL: http://testkube-enterprise-dex.{{.Release.Namespace}}.svc.cluster.local:5556/keys
   api:
     # -- Configure which invitation mode to use (email|auto-accept): email uses SMTP protocol to send email invites and auto-accept immediately adds them
-    inviteMode: email
+    inviteMode: auto-accept
     features:
       disablePersonalOrgs: true
       bootstrapOrg: "demo"
       bootstrapEnv: "my-first-environment"
       bootstrapAgentTokenSecretRef: "testkube-default-agent-token"
-      bootstrapAdmin: "admin@example.com"
     migrations:
       enabled: false
     mongo:

--- a/charts/testkube-enterprise/templates/_helpers.tpl
+++ b/charts/testkube-enterprise/templates/_helpers.tpl
@@ -26,3 +26,26 @@ Get Storage Ingress host
 {{- .Values.minio.customIngress.host }}
 {{- end }}
 {{- end }}
+
+{{/*
+Define API image
+*/}}
+{{- define "testkube-shared-secrets.image" -}}
+{{- $registryName := default "docker.io" .Values.sharedSecretGenerator.image.registry -}}
+{{- $repositoryName := default "bitnami/kubectl" .Values.sharedSecretGenerator.image.repository -}}
+{{- $tag := default "1.28.2" .Values.sharedSecretGenerator.image.tag | toString -}}
+{{- $separator := ":" -}}
+{{- if .Values.sharedSecretGenerator.image.digest }}
+    {{- $separator = "@" -}}
+    {{- $tag = .Values.sharedSecretGenerator.image.digest | toString -}}
+{{- end -}}
+{{- if .Values.global }}
+    {{- if .Values.global.imageRegistry }}
+        {{- printf "%s/%s%s%s" .Values.global.imageRegistry $repositoryName $separator $tag -}}
+    {{- else -}}
+        {{- printf "%s/%s%s%s" $registryName $repositoryName $separator $tag -}}
+    {{- end -}}
+{{- else -}}
+    {{- printf "%s/%s%s%s" $registryName $repositoryName $separator $tag -}}
+{{- end -}}
+{{- end -}}

--- a/charts/testkube-enterprise/templates/shared-secrets/job.yaml
+++ b/charts/testkube-enterprise/templates/shared-secrets/job.yaml
@@ -15,7 +15,7 @@ spec:
       restartPolicy: Never
       containers:
         - name: {{ .Chart.Name }}
-          image: {{ default "registry.gitlab.com/gitlab-org/build/cng/kubectl" .Values.sharedSecretGenerator.image }}
+          image: {{ include "testkube-shared-secrets.image" . }}
           command: ['/bin/bash', '/scripts/generate-secrets']
           volumeMounts:
             - name: scripts

--- a/charts/testkube-enterprise/values.yaml
+++ b/charts/testkube-enterprise/values.yaml
@@ -46,12 +46,13 @@ global:
   dex:
     # -- Global Dex issuer url which is configured both in Dex and API
     issuer: ""
+
 sharedSecretGenerator:
   enabled: false
   securityContext: {}
   resources: {}
-  ## Optional settings
-  # image:
+  image: {}
+
 minio:
   # -- Toggle whether to install MinIO
   enabled: true

--- a/charts/testkube-logs-service/templates/_helpers.tpl
+++ b/charts/testkube-logs-service/templates/_helpers.tpl
@@ -93,7 +93,7 @@ Define image
 {{- define "testkube-logs.image" -}}
 {{- $registryName := default "docker.io" .Values.image.registry -}}
 {{- $repositoryName := .Values.image.repository -}}
-{{- $tag := default .Chart.AppVersion .Values.image.tag | toString -}}
+{{- $tag := default .Values.image.tag .Chart.AppVersion | toString -}}
 {{- $separator := ":" -}}
 {{- if .Values.image.digest }}
     {{- $separator = "@" -}}

--- a/charts/testkube-logs-service/templates/_helpers.tpl
+++ b/charts/testkube-logs-service/templates/_helpers.tpl
@@ -86,3 +86,26 @@ THIS IS A HACK TO WORKAROUND LET'S ENCRYPT RATE LIMITS
 {{- define "testkube-log-service.ingress.hackHost" -}}
 {{- printf "health.%s" .Values.global.domain }}
 {{- end }}
+
+{{/*
+Define image
+*/}}
+{{- define "testkube-logs.image" -}}
+{{- $registryName := default "docker.io" .Values.image.registry -}}
+{{- $repositoryName := .Values.image.repository -}}
+{{- $tag := default .Chart.AppVersion .Values.image.tag | toString -}}
+{{- $separator := ":" -}}
+{{- if .Values.image.digest }}
+    {{- $separator = "@" -}}
+    {{- $tag = .Values.image.digest | toString -}}
+{{- end -}}
+{{- if .Values.global }}
+    {{- if .Values.global.imageRegistry }}
+        {{- printf "%s/%s%s%s" .Values.global.imageRegistry $repositoryName $separator $tag -}}
+    {{- else -}}
+        {{- printf "%s/%s%s%s" $registryName $repositoryName $separator $tag -}}
+    {{- end -}}
+{{- else -}}
+    {{- printf "%s/%s%s%s" $registryName $repositoryName $separator $tag -}}
+{{- end -}}
+{{- end -}}

--- a/charts/testkube-logs-service/templates/deployment.yaml
+++ b/charts/testkube-logs-service/templates/deployment.yaml
@@ -34,8 +34,8 @@ spec:
         - name: {{ .Chart.Name }}
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
-          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
-          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          image: {{ include "testkube-logs.image" . }}
+          imagePullPolicy: {{ .Values.global.imagePullPolicy | default .Values.image.pullPolicy }}
           env:
             - name: DEBUG
               value: "false"

--- a/charts/testkube-worker-service/templates/_helpers.tpl
+++ b/charts/testkube-worker-service/templates/_helpers.tpl
@@ -122,7 +122,7 @@ Define image
 {{- define "testkube-worker.image" -}}
 {{- $registryName := default "docker.io" .Values.image.registry -}}
 {{- $repositoryName := .Values.image.repository -}}
-{{- $tag := default .Chart.AppVersion .Values.image.tag | toString -}}
+{{- $tag := default .Values.image.tag .Chart.AppVersion | toString -}}
 {{- $separator := ":" -}}
 {{- if .Values.image.digest }}
     {{- $separator = "@" -}}

--- a/charts/testkube-worker-service/templates/_helpers.tpl
+++ b/charts/testkube-worker-service/templates/_helpers.tpl
@@ -115,3 +115,26 @@ THIS IS A HACK TO WORKAROUND LET'S ENCRYPT RATE LIMITS
 {{- define "testkube-worker-service.ingress.hackHost" -}}
 {{- printf "health.%s" .Values.global.domain }}
 {{- end }}
+
+{{/*
+Define image
+*/}}
+{{- define "testkube-worker.image" -}}
+{{- $registryName := default "docker.io" .Values.image.registry -}}
+{{- $repositoryName := .Values.image.repository -}}
+{{- $tag := default .Chart.AppVersion .Values.image.tag | toString -}}
+{{- $separator := ":" -}}
+{{- if .Values.image.digest }}
+    {{- $separator = "@" -}}
+    {{- $tag = .Values.image.digest | toString -}}
+{{- end -}}
+{{- if .Values.global }}
+    {{- if .Values.global.imageRegistry }}
+        {{- printf "%s/%s%s%s" .Values.global.imageRegistry $repositoryName $separator $tag -}}
+    {{- else -}}
+        {{- printf "%s/%s%s%s" $registryName $repositoryName $separator $tag -}}
+    {{- end -}}
+{{- else -}}
+    {{- printf "%s/%s%s%s" $registryName $repositoryName $separator $tag -}}
+{{- end -}}
+{{- end -}}

--- a/charts/testkube-worker-service/templates/deployment.yaml
+++ b/charts/testkube-worker-service/templates/deployment.yaml
@@ -34,8 +34,8 @@ spec:
         - name: {{ .Chart.Name }}
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
-          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
-          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          image: {{ include "testkube-worker.image" . }}
+          imagePullPolicy: {{ .Values.global.imagePullPolicy | default .Values.image.pullPolicy }}
           env:
             - name: METRICS_LISTEN_ADDR
               value: "0.0.0.0:9100"


### PR DESCRIPTION
This PR:

- Removes bootstrapAdmin by leveraging default_organization and default_environments to auto-join. This is for the demo profile. The benefit is that it's easier to use different e-mails than admin@example.com as it only has to be updated in one place and that multiple admins can also exist.
- Introduces registry overrides by Bitnami standard, i.e. `global.imageRegistry`.