### PR TITLE
fix: use Minio as default storage for worker service

### DIFF
--- a/charts/testkube-enterprise/values.yaml
+++ b/charts/testkube-enterprise/values.yaml
@@ -310,6 +310,11 @@ testkube-worker-service:
   api:
     nats:
       uri: "nats://testkube-enterprise-nats:4222"
+    minio:
+      accessKeyId: *minioRootUser
+      secretAccessKey: *minioRootPassword
+  additionalEnv:
+    USE_MINIO: true
 testkube-logs-service:
   enabled: true
   fullnameOverride: testkube-enterprise-logs-service


### PR DESCRIPTION
Checklist:

* [x] Any new values are backwards compatible and/or have sensible default.
* [ ] I have signed off all my commits as required by [DCO](https://github.com/kubeshop/testkube-cloud-charts/blob/master/community/CONTRIBUTING.md).
* [ ] My CI is green.

<!-- Changes are automatically published when merged to `main`. They are not published on branches. -->