### PR TITLE
fix: make default minio endpoint not-namespace specific

### DIFF
--- a/charts/testkube-enterprise/values.yaml
+++ b/charts/testkube-enterprise/values.yaml
@@ -313,7 +313,7 @@ testkube-worker-service:
     minio:
       accessKeyId: *minioRootUser
       secretAccessKey: *minioRootPassword
-      endpoint: testkube-enterprise-minio.testkube-enterprise.svc.cluster.local:9000
+      endpoint: testkube-enterprise-minio:9000
   additionalEnv:
     USE_MINIO: true
 testkube-logs-service:


### PR DESCRIPTION
Checklist:

* [x] Any new values are backwards compatible and/or have sensible default.
* [ ] I have signed off all my commits as required by [DCO](https://github.com/kubeshop/testkube-cloud-charts/blob/master/community/CONTRIBUTING.md).
* [ ] My CI is green.

<!-- Changes are automatically published when merged to `main`. They are not published on branches. -->