### PR TITLE
feat: testkube-enterprise: add support for defining common labels

### DIFF
--- a/charts/testkube-cloud-api/templates/_helpers.tpl
+++ b/charts/testkube-cloud-api/templates/_helpers.tpl
@@ -38,6 +38,9 @@ app.kubernetes.io/version: {{ .Values.image.tag | quote }}
 app.kubernetes.io/component: backend
 {{ include "testkube-cloud-api.selectorLabels" . }}
 {{ include "testkube-cloud-api.baseLabels" . }}
+{{- if .Values.global.labels }}
+{{ toYaml .Values.global.labels }}
+{{- end }}
 {{- end }}
 
 {{/*

--- a/charts/testkube-cloud-api/values.yaml
+++ b/charts/testkube-cloud-api/values.yaml
@@ -42,7 +42,11 @@ global:
   dex:
     # -- Global Dex issuer url
     issuer: ""
+  # -- Common labels which will be added to all resources
+  labels: {}
+
 replicaCount: 1
+
 image:
   repository: kubeshop/testkube-cloud-api
   pullPolicy: IfNotPresent

--- a/charts/testkube-cloud-ui/templates/_helpers.tpl
+++ b/charts/testkube-cloud-ui/templates/_helpers.tpl
@@ -40,6 +40,9 @@ app.kubernetes.io/version: {{ .Values.image.tag | quote }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
 app.kubernetes.io/component: frontend
 app.kubernetes.io/part-of: testkube-{{ if .Values.global.enterpriseMode }}enterprise{{ else }}cloud{{ end }}
+{{- if .Values.global.labels }}
+{{ toYaml .Values.global.labels }}
+{{- end }}
 {{- end }}
 
 {{/*

--- a/charts/testkube-cloud-ui/values.yaml
+++ b/charts/testkube-cloud-ui/values.yaml
@@ -21,7 +21,11 @@ global:
   ingress:
     # -- Global toggle whether to create Ingress resources
     enabled: true
+  # -- Common labels which will be added to all resources
+  labels: {}
+
 replicaCount: 1
+
 sentry:
   # -- Toggle whether to enable Sentry.io error reporting
   enabled: false

--- a/charts/testkube-enterprise/README.md
+++ b/charts/testkube-enterprise/README.md
@@ -30,6 +30,7 @@ A Helm chart for Testkube Enterprise
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
+| dex.commonLabels | object | `{}` | Common labels which will be added to all Dex resources |
 | dex.configSecret.create | bool | `false` | This should be set to `false` so Dex does not create the config secret. Refer to the `createCustom` field for more info on creating config secret. |
 | dex.configSecret.createCustom | bool | `true` | Toggle whether to create a custom config secret for Dex (templates/dex-config-secret.yaml). If set to `true`, the `configTemplate` field will be used to generate the config secret. |
 | dex.configSecret.name | string | `"testkube-enterprise-dex-config"` | The name of the secret to mount as configuration in the pod. Set `createCustom: false` and edit the secret manually to use a custom config secret. |
@@ -68,6 +69,7 @@ A Helm chart for Testkube Enterprise
 | global.grpcApiSubdomain | string | `"agent"` | gRPC API subdomain which get prepended to the domain |
 | global.imagePullSecrets | list | `[]` | Image pull secrets to use for testkube-cloud-api and testkube-cloud-ui |
 | global.ingress.enabled | bool | `true` | Global toggle whether to create Ingress resources |
+| global.labels | object | `{}` | Common labels which will be added to all resources |
 | global.logsSubdomain | string | `"logs"` | UI subdomain which get prepended to the domain |
 | global.redirectSubdomain | string | `"app"` | Different UI subdomain which gets prepended to the domain. May be used for the redirect from your actual uiSubdomain endpoint. Works is ingressRedirect option is enabled. |
 | global.restApiSubdomain | string | `"api"` | REST API subdomain which get prepended to the domain |
@@ -79,6 +81,7 @@ A Helm chart for Testkube Enterprise
 | minio.auth.existingSecret | string | `""` | Use existing secret for credentials details (`auth.rootUser` and `auth.rootPassword` will be ignored and picked up from this secret). The secret has to contain the keys `root-user` and `root-password`) |
 | minio.auth.rootPassword | string | `"t3stkub3-3nt3rpr1s3"` | MinIO root password (secret key) |
 | minio.auth.rootUser | string | `"testkube-enterprise"` | MinIO root username (access key) |
+| minio.commonLabels | object | `{}` | Common labels which will be added to all MinIO resources |
 | minio.containerSecurityContext.allowPrivilegeEscalation | bool | `false` |  |
 | minio.containerSecurityContext.capabilities.drop[0] | string | `"ALL"` |  |
 | minio.containerSecurityContext.enabled | bool | `true` | Toggle whether to render the container security context |
@@ -107,6 +110,7 @@ A Helm chart for Testkube Enterprise
 | minio.tls.existingSecret | string | `""` | Name of an existing secret holding the certificate information |
 | minio.tolerations | list | `[]` | Tolerations to schedule a workload to nodes with any architecture type. Required for deployment to GKE cluster. |
 | mongodb.auth.enabled | bool | `false` | Toggle whether to enable MongoDB authentication |
+| mongodb.commonLabels | object | `{}` | Common labels which will be added to all MongoDB resources |
 | mongodb.containerSecurityContext | object | `{}` | Security Context for MongoDB container |
 | mongodb.enabled | bool | `true` | Toggle whether to install MongoDB |
 | mongodb.fullnameOverride | string | `"testkube-enterprise-mongodb"` | MongoDB fullname override |
@@ -115,12 +119,13 @@ A Helm chart for Testkube Enterprise
 | mongodb.tolerations | list | `[]` |  |
 | nats.config.cluster.enabled | bool | `true` | Enable cluster mode (HA) |
 | nats.config.cluster.replicas | int | `3` | NATS cluster replicas |
-| nats.config.jetstream.enabled | bool | `true` |  |
+| nats.config.jetstream.enabled | bool | `true` | Toggle whether to enable JetStream (Testkube requires JetStream to be enabled, so this setting should always be on) |
 | nats.config.jetstream.fileStore.pvc.enabled | bool | `true` |  |
 | nats.config.jetstream.fileStore.pvc.size | string | `"10Gi"` |  |
 | nats.config.jetstream.fileStore.pvc.storageClassName | string | `nil` |  |
 | nats.config.merge | object | `{"cluster":{"name":"<< testkube-enterprise >>"},"max_payload":"<< 8MB >>"}` | Merge additional fields to nats config https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#container-v1-core |
 | nats.config.patch | list | `[]` | Patch additional fields to nats config |
+| nats.enabled | bool | `true` | Toggle whether to install NATS |
 | nats.fullnameOverride | string | `"testkube-enterprise-nats"` |  |
 | nats.natsBox.enabled | bool | `true` |  |
 | nats.natsBox.env | object | `{}` | Map of additional env vars |
@@ -138,7 +143,7 @@ A Helm chart for Testkube Enterprise
 | sharedSecretGenerator.image | object | `{}` |  |
 | sharedSecretGenerator.resources | object | `{}` |  |
 | sharedSecretGenerator.securityContext | object | `{}` |  |
-| testkube-agent.enabled | bool | `false` |  |
+| testkube-agent.enabled | bool | `false` | Toggle whether to install & connect Testkube Agent in the same cluster |
 | testkube-cloud-api.ai.secretRef | string | `""` |  |
 | testkube-cloud-api.api.agent.healthcheck.lock | string | `"kv"` | Agent healthcheck distributed mode (one of mongo|kv) - used for pods sync to run healthchecks on single pod at once |
 | testkube-cloud-api.api.agent.hide | bool | `false` |  |
@@ -209,7 +214,8 @@ A Helm chart for Testkube Enterprise
 | testkube-cloud-ui.ingress.tlsSecretName | string | `"testkube-enterprise-ui-tls"` | Name of the TLS secret which contains the certificate files |
 | testkube-cloud-ui.ingressRedirect | object | `{"enabled":false}` | Toggle whether to enable redirect Ingress which allows having a different subdomain redirecting to the actual Dashboard UI Ingress URL |
 | testkube-cloud-ui.ui.authStrategy | string | `""` | Auth strategy to use (possible values: "" (default), "gitlab", "github"), setting to "" enables all auth strategies, if you use a custom Dex connector, set this to the id of the connector |
-| testkube-logs-service.additionalEnv.USE_MINIO | bool | `true` |  |
+| testkube-logs-service.additionalEnv | object | `{"USE_MINIO":true}` | Additional env vars to set |
+| testkube-logs-service.additionalEnv.USE_MINIO | bool | `true` | Enterprise should use MinIO for storage and this envvar should not be changed |
 | testkube-logs-service.api.minio.accessKeyId | string | `"testkube-enterprise"` | MinIO access key id |
 | testkube-logs-service.api.minio.certSecret.baseMountPath | string | `"/etc/client-certs/storage"` | Base path to mount the client certificate secret |
 | testkube-logs-service.api.minio.certSecret.caFile | string | `"ca.crt"` | Path to ca file (used for self-signed certificates) |
@@ -236,9 +242,9 @@ A Helm chart for Testkube Enterprise
 | testkube-logs-service.api.tls.certPath | string | `"/tmp/serving-cert/crt.pem"` | certificate path |
 | testkube-logs-service.api.tls.keyPath | string | `"/tmp/serving-cert/key.pem"` | certificate key path |
 | testkube-logs-service.api.tls.serveHTTPS | bool | `false` | Toggle should the Application terminate TLS instead of the Ingress |
-| testkube-logs-service.enabled | bool | `true` |  |
+| testkube-logs-service.enabled | bool | `true` | Toggle whether to install Testkube Logs Service |
 | testkube-logs-service.fullnameOverride | string | `"testkube-enterprise-logs-service"` |  |
-| testkube-logs-service.grpcIngress.enabled | bool | `true` |  |
+| testkube-logs-service.grpcIngress.enabled | bool | `true` | Toggle whether to enable gRPC Ingress for Logs Service |
 | testkube-logs-service.grpcIngress.host | string | `""` |  |
 | testkube-logs-service.image.tag | string | `"v0-20240315-134446"` |  |
 | testkube-logs-service.testConnection.enabled | bool | `false` |  |
@@ -252,4 +258,4 @@ A Helm chart for Testkube Enterprise
 | testkube-worker-service.image.tag | string | `"1.9.4"` |  |
 
 ----------------------------------------------
-Autogenerated from chart metadata using [helm-docs v1.11.0](https://github.com/norwoodj/helm-docs/releases/v1.11.0)
+Autogenerated from chart metadata using [helm-docs v1.13.1](https://github.com/norwoodj/helm-docs/releases/v1.13.1)

--- a/charts/testkube-enterprise/values.yaml
+++ b/charts/testkube-enterprise/values.yaml
@@ -46,15 +46,22 @@ global:
   dex:
     # -- Global Dex issuer url which is configured both in Dex and API
     issuer: ""
+  # -- Common labels which will be added to all resources
+  labels: &common_labels {}
+
 sharedSecretGenerator:
   enabled: false
   securityContext: {}
   resources: {}
   image: {}
+
 minio:
   # -- Toggle whether to install MinIO
   enabled: true
   fullnameOverride: &minioFullnameOverride testkube-enterprise-minio
+  # -- Common labels which will be added to all MinIO resources
+  commonLabels: *common_labels
+
   # Uncomment if you want to provide different image settings
   # image:
   # registry: docker.io
@@ -68,6 +75,7 @@ minio:
   # repository: bitnami/minio-client
   # tag: 2023.11.20-debian-11-r0
   # digest: ""
+
   auth:
     # -- MinIO root username (access key)
     rootUser: &minioRootUser "testkube-enterprise"
@@ -142,6 +150,7 @@ minio:
     tls:
       # -- TLS secret name which contains the certificate files
       tlsSecret: testkube-enterprise-minio-tls
+
 ## Testkube Cloud API chart parameters
 testkube-cloud-api:
   fullnameOverride: testkube-enterprise-api
@@ -286,6 +295,8 @@ testkube-cloud-api:
   ##Test Connection pod
   testConnection:
     enabled: false
+
+## Testkube Cloud UI chart parameters
 testkube-cloud-ui:
   fullnameOverride: testkube-enterprise-ui
   ui:
@@ -300,8 +311,13 @@ testkube-cloud-ui:
   # -- Toggle whether to enable redirect Ingress which allows having a different subdomain redirecting to the actual Dashboard UI Ingress URL
   ingressRedirect:
     enabled: false
+
+## Testkube chart parameters
 testkube-agent:
+  # -- Toggle whether to install & connect Testkube Agent in the same cluster
   enabled: false
+
+## Testkube Worker Service chart parameters
 testkube-worker-service:
   fullnameOverride: testkube-enterprise-worker-service
   image:
@@ -316,12 +332,18 @@ testkube-worker-service:
       endpoint: testkube-enterprise-minio:9000
   additionalEnv:
     USE_MINIO: true
+
+## Testkube Logs Service chart parameters
 testkube-logs-service:
+  # -- Toggle whether to install Testkube Logs Service
   enabled: true
   fullnameOverride: testkube-enterprise-logs-service
+  # -- Additional env vars to set
   additionalEnv:
+    # -- Enterprise should use MinIO for storage and this envvar should not be changed
     USE_MINIO: true
   grpcIngress:
+    # -- Toggle whether to enable gRPC Ingress for Logs Service
     enabled: true
     host: ""
   api:
@@ -385,12 +407,15 @@ testkube-logs-service:
         caFile: "ca.crt"
   image:
     tag: v0-20240315-134446
-  ##Test Connection pod
+  ## Test Connection pod
   testConnection:
     enabled: false
+
 ## NATS chart parameter
 ## For more configuration parameters of NATS chart please look here: https://docs.nats.io/running-a-nats-service/nats-kubernetes/helm-charts
 nats:
+  # -- Toggle whether to install NATS
+  enabled: true
   fullnameOverride: testkube-enterprise-nats
   # Uncomment if you want to provide a different image or pullPolicy
   # container:
@@ -406,6 +431,7 @@ nats:
       # -- NATS cluster replicas
       replicas: 3
     jetstream:
+      # -- Toggle whether to enable JetStream (Testkube requires JetStream to be enabled, so this setting should always be on)
       enabled: true
       fileStore:
         pvc:
@@ -479,11 +505,13 @@ nats:
     merge: {}
     # -- Patch additional fields to the container
     patch: []
+
 ## MongoDB chart parameters
 ## For more configuration parameters of MongoDB chart please look here: https://github.com/bitnami/charts/tree/master/bitnami/mongodb#parameters
 mongodb:
   # -- Toggle whether to install MongoDB
   enabled: true
+
   # Uncomment if you want to provide different image settings
   # image:
   # registry: docker.io
@@ -493,6 +521,8 @@ mongodb:
 
   # -- MongoDB fullname override
   fullnameOverride: "testkube-enterprise-mongodb"
+  # -- Common labels which will be added to all MongoDB resources
+  commonLabels: *common_labels
   # MongoDB Auth settings
   auth:
     # -- Toggle whether to enable MongoDB authentication
@@ -517,17 +547,23 @@ mongodb:
   #    enabled: true
   #    runAsUser: 1001010000
   #    runAsNonRoot: true
+
 ## Dex chart parameters
 ## For more configuration parameters of NATS chart please look here: https://github.com/dexidp/helm-charts
 dex:
   # -- Toggle whether to install Dex
   enabled: true
   fullnameOverride: testkube-enterprise-dex
+
   # Uncomment if you want to provide different image settings
   # image:
   # repository: ghcr.io/dexidp/dex
   # tag: v2.36.0-alpine
   # pullPolicy: IfNotPresent
+
+  # -- Common labels which will be added to all Dex resources
+  commonLabels: *common_labels
+
   rbac:
     # -- Specifies whether RBAC resources should be created.
     # If disabled, the operator is responsible for creating the necessary resources based on the templates.

--- a/charts/testkube-logs-service/templates/_helpers.tpl
+++ b/charts/testkube-logs-service/templates/_helpers.tpl
@@ -38,6 +38,9 @@ app.kubernetes.io/version: {{ .Values.image.tag | quote }}
 app.kubernetes.io/component: backend
 {{ include "testkube-log-service.selectorLabels" . }}
 {{ include "testkube-log-service.baseLabels" . }}
+{{- if .Values.global.labels }}
+{{ toYaml .Values.global.labels }}
+{{- end }}
 {{- end }}
 
 {{/*

--- a/charts/testkube-logs-service/values.yaml
+++ b/charts/testkube-logs-service/values.yaml
@@ -17,6 +17,8 @@ global:
   ingress:
     # -- Toggle whether to enable or disable all Ingress resources (if false, all Ingress resources will be disabled and cannot be overriden)
     enabled: true
+  # -- Common labels which will be added to all resources
+  labels: {}
 
 replicaCount: 1
 image:

--- a/charts/testkube-worker-service/templates/_helpers.tpl
+++ b/charts/testkube-worker-service/templates/_helpers.tpl
@@ -38,6 +38,9 @@ app.kubernetes.io/version: {{ .Values.image.tag | quote }}
 app.kubernetes.io/component: backend
 {{ include "testkube-worker-service.selectorLabels" . }}
 {{ include "testkube-worker-service.baseLabels" . }}
+{{- if .Values.global.labels }}
+{{ toYaml .Values.global.labels }}
+{{- end }}
 {{- end }}
 
 {{/*

--- a/charts/testkube-worker-service/values.yaml
+++ b/charts/testkube-worker-service/values.yaml
@@ -4,14 +4,20 @@
 
 global:
   imagePullSecrets: []
+  # -- Common labels which will be added to all resources
+  labels: {}
+
 replicaCount: 1
+
 image:
   repository: kubeshop/testkube-worker-service
   pullPolicy: IfNotPresent
   tag: "1.9.4"
 imagePullSecrets: []
+
 nameOverride: ""
 fullnameOverride: ""
+
 # -- Additional env vars to be added to the deployment
 additionalEnv: {}
 # FOO: bar


### PR DESCRIPTION
If you want to define common labels (labels which will be applied to all Kubernetes resources), set the following parameter:
```
global:
  labels:
    foo: bar
```