### PR TITLE
testkube-enterprise: pinpoint enterprise worker service to v1.9.1

### DIFF
--- a/charts/testkube-enterprise/profiles/values.demo.yaml
+++ b/charts/testkube-enterprise/profiles/values.demo.yaml
@@ -116,7 +116,7 @@ testkube-worker-service:
   fullnameOverride: testkube-enterprise-worker-service
   image:
     repository: kubeshop/testkube-enterprise-worker-service
-    tag: 1.9.4
+    tag: 1.9.1
   api:
     nats:
       uri: "nats://testkube-enterprise-nats.{{.Release.Namespace}}.svc.cluster.local:4222"

--- a/charts/testkube-enterprise/values.yaml
+++ b/charts/testkube-enterprise/values.yaml
@@ -326,7 +326,7 @@ testkube-worker-service:
   fullnameOverride: testkube-enterprise-worker-service
   image:
     repository: kubeshop/testkube-enterprise-worker-service
-    tag: 1.9.4
+    tag: 1.9.1
   api:
     nats:
       uri: "nats://testkube-enterprise-nats:4222"


### PR DESCRIPTION
Checklist:

* [ ] Any new values are backwards compatible and/or have sensible default.
* [ ] I have signed off all my commits as required by [DCO](https://github.com/kubeshop/testkube-cloud-charts/blob/master/community/CONTRIBUTING.md).
* [ ] My CI is green.

<!-- Changes are automatically published when merged to `main`. They are not published on branches. -->