### PR TITLE
fix: remove dependence on ingresses for dex configuration

### DIFF
--- a/charts/testkube-cloud-api/values.yaml
+++ b/charts/testkube-cloud-api/values.yaml
@@ -13,7 +13,7 @@ global:
   enterpriseLicenseFile: ""
   # -- Enterprise license file secret reference. Place the license key under the key `LICENSE_KEY` key in the secret, and in case of an offline license place the license file under the key `license.lic` in the same secret. Make sure that the license key file does not have any new line characters at the end of the file.
   enterpriseLicenseSecretRef: ""
-  # -- Domain under which to create Ingress rules
+  # -- Domain under which endpoints are exposed
   domain: ""
   # -- UI subdomain which get prepended to the domain
   uiSubdomain: "cloud"

--- a/charts/testkube-enterprise/local-values.yaml
+++ b/charts/testkube-enterprise/local-values.yaml
@@ -13,7 +13,7 @@ global:
   enterpriseLicenseFile: ""
   # -- Enterprise license file secret reference. Place the license key under the key `LICENSE_KEY` key in the secret, and in case of an offline license place the license file under the key `license.lic` in the same secret. Make sure that the license key file does not have any new line characters at the end of the file.
   enterpriseLicenseSecretRef: "testkube-enterprise-license"
-  # -- Domain under which to create Ingress rules
+  # -- Domain under which endpoints are exposed
   domain: ""
   # -- UI subdomain which get prepended to the domain
   uiSubdomain: "dashboard"

--- a/charts/testkube-enterprise/templates/dex-config-secret.yaml
+++ b/charts/testkube-enterprise/templates/dex-config-secret.yaml
@@ -28,12 +28,12 @@ stringData:
         name: 'Testkube Enterprise'
         secret: '{{ $api.api.oauth.clientSecret }}'
         redirectURIs:
-          - '{{ if .Values.global.ingress.enabled }}https://{{ .Values.global.restApiSubdomain }}.{{ .Values.global.domain }}/auth/callback{{ else }}http://localhost:8090/auth/callback{{ end }}'
+          - '{{ if .Values.global.domain }}https://{{ .Values.global.restApiSubdomain }}.{{ .Values.global.domain }}/auth/callback{{ else }}http://localhost:8090/auth/callback{{ end }}'
       - id: teskube-cloud-cli
         name: 'Testkube Enterprise CLI'
         secret: '{{ $api.api.oauth.clientSecret }}'
         redirectURIs:
-          - '{{ if .Values.global.ingress.enabled }}https://{{ .Values.global.restApiSubdomain }}.{{ .Values.global.domain }}/auth/callback{{ else }}http://localhost:8090/auth/callback{{ end }}'
+          - '{{ if .Values.global.domain }}https://{{ .Values.global.restApiSubdomain }}.{{ .Values.global.domain }}/auth/callback{{ else }}http://localhost:8090/auth/callback{{ end }}'
       {{- if .Values.dex.configTemplate.additionalStaticClients }}
       {{- toYaml .Values.dex.configTemplate.additionalStaticClients | nindent 6 }}
       {{- end }}

--- a/charts/testkube-enterprise/values.yaml
+++ b/charts/testkube-enterprise/values.yaml
@@ -13,7 +13,7 @@ global:
   enterpriseLicenseFile: ""
   # -- Enterprise license file secret reference. Place the license key under the key `LICENSE_KEY` key in the secret, and in case of an offline license place the license file under the key `license.lic` in the same secret. Make sure that the license key file does not have any new line characters at the end of the file.
   enterpriseLicenseSecretRef: ""
-  # -- Domain under which to create Ingress rules
+  # -- Domain under which endpoints are exposed
   domain: ""
   # -- UI subdomain which get prepended to the domain
   logsSubdomain: "logs"


### PR DESCRIPTION
Fixes TKC-1970

Checklist:

* [ ] Any new values are backwards compatible and/or have sensible default.
* [ ] I have signed off all my commits as required by [DCO](https://github.com/kubeshop/testkube-cloud-charts/blob/master/community/CONTRIBUTING.md).
* [ ] My CI is green.

<!-- Changes are automatically published when merged to `main`. They are not published on branches. -->