### PR TITLE
feat: require smtp/email setup in the "email" invite mode

### DIFF
--- a/charts/testkube-cloud-api/templates/deployment.yaml
+++ b/charts/testkube-cloud-api/templates/deployment.yaml
@@ -87,12 +87,18 @@ spec:
             - name: INVITE_MODE
               value: "{{ .Values.api.inviteMode }}"
             {{- if eq .Values.api.inviteMode "email" }}
+            {{- $check := required ".Values.api.email needs to be configured with .Values.api.inviteMode set to \"email\"" .Values.api.email -}}
+            {{- $check := required ".Values.api.smtp needs to be configured with .Values.api.inviteMode set to \"email\"" .Values.api.smtp }}
+            - name: FROM_EMAIL
+              value: "{{ required ".Values.api.email.fromEmail is required with .Values.api.inviteMode set to \"email\"" .Values.api.email.fromEmail }}"
+            - name: FROM_NAME
+              value: "{{ required ".Values.api.email.fromName is required with .Values.api.inviteMode set to \"email\"" .Values.api.email.fromName }}"
             - name: SMTP_HOST
-              value: "{{ .Values.api.smtp.host }}"
+              value: "{{ required ".Values.api.smtp.host is required with .Values.api.inviteMode set to \"email\"" .Values.api.smtp.host }}"
             - name: SMTP_PORT
-              value: "{{ .Values.api.smtp.port }}"
+              value: "{{ required ".Values.api.smtp.port is required with .Values.api.inviteMode set to \"email\"" .Values.api.smtp.port }}"
             - name: SMTP_USER
-              value: "{{ .Values.api.smtp.username }}"
+              value: "{{ required ".Values.api.smtp.username is required with .Values.api.inviteMode set to \"email\"" .Values.api.smtp.username }}"
             - name: SMTP_PASS
               {{- if .Values.api.smtp.passwordSecretRef }}
               valueFrom:
@@ -100,13 +106,9 @@ spec:
                   key: SMTP_PASS
                   name: {{ .Values.api.smtp.passwordSecretRef }}
               {{- else }}
-              value: "{{ .Values.api.smtp.password }}"
+              value: "{{ required ".Values.api.smtp.password is required with .Values.api.inviteMode set to \"email\"" .Values.api.smtp.password }}"
               {{- end }}
             {{- end }}
-            - name: FROM_EMAIL
-              value: "{{ .Values.api.email.fromEmail }}"
-            - name: FROM_NAME
-              value: "{{ .Values.api.email.fromName }}"
             - name: ROOT_DOMAIN
               value: "{{ .Values.global.domain }}"
             - name: METRICS_LISTEN_ADDR

--- a/charts/testkube-cloud-api/values.yaml
+++ b/charts/testkube-cloud-api/values.yaml
@@ -109,21 +109,21 @@ api:
       enabled: false
       config: {}
   # -- Configure which invitation mode to use (email|auto-accept): email uses SMTP protocol to send email invites and auto-accept immediately adds them
-  inviteMode: email
-  email:
-    fromEmail: "noreply@kubeshop.io"
-    fromName: "Testkube Cloud"
-  smtp:
-    # -- SMTP host
-    host: smtp.example.com
-    # -- SMTP port
-    port: 587
-    # -- SMTP username
-    username: ""
-    # -- SMTP password
-    password: ""
-    # -- SMTP secret ref (secret must contain key SMTP_PASSWORD), overrides password field if defined
-    passwordSecretRef: ""
+  inviteMode: auto-accept
+# email:
+#   fromEmail: "noreply@kubeshop.io"
+#   fromName: "Testkube Cloud"
+# smtp:
+#   # -- SMTP host
+#   host: smtp.example.com
+#   # -- SMTP port
+#   port: 587
+#   # -- SMTP username
+#   username: ""
+#   # -- SMTP password
+#   password: ""
+#   # -- SMTP secret ref (secret must contain key SMTP_PASSWORD), overrides password field if defined
+#    passwordSecretRef: ""
   tls:
     # -- Toggle should the Application terminate TLS instead of the Ingress
     serveHTTPS: true

--- a/charts/testkube-enterprise/values.yaml
+++ b/charts/testkube-enterprise/values.yaml
@@ -212,18 +212,21 @@ testkube-cloud-api:
       # -- TLS CA certificate file
       caFile: ""
     # -- Configure which invitation mode to use (email|auto-accept): email uses SMTP protocol to send email invites and auto-accept immediately adds them
-    inviteMode: email
-    smtp:
-      # -- SMTP host
-      host: ""
-      # -- SMTP port
-      port: 587
-      # -- SMTP username
-      username: ""
-      # -- SMTP password
-      password: ""
-      # -- SMTP secret ref (secret must contain key SMTP_PASSWORD), overrides password field if defined
-      passwordSecretRef: ""
+    inviteMode: auto-accept
+#   email:
+#     fromEmail: "noreply@kubeshop.io"
+#     fromName: "Testkube Cloud"
+#   smtp:
+#     # -- SMTP host
+#     host: smtp.example.com
+#     # -- SMTP port
+#     port: 587
+#     # -- SMTP username
+#     username: ""
+#     # -- SMTP password
+#     password: ""
+#     # -- SMTP secret ref (secret must contain key SMTP_PASSWORD), overrides password field if defined
+#      passwordSecretRef: ""
     tls:
       certManager:
         # -- Certificate Issuer kind (only used if `provider` is set to `cert-manager`)


### PR DESCRIPTION
Also sets the default invitte mode to "auto-accept" to ease the basic installations.

**Note**, this is technically a breaking change as we are changing default values.

Checklist:

* [ ] Any new values are backwards compatible and/or have sensible default.
* [ ] I have signed off all my commits as required by [DCO](https://github.com/kubeshop/testkube-cloud-charts/blob/master/community/CONTRIBUTING.md).
* [ ] My CI is green.

<!-- Changes are automatically published when merged to `main`. They are not published on branches. -->