### PR TITLE
fix: bootstrapUser config to user owner role instead of admin

### DIFF
--- a/charts/testkube-cloud-api/templates/bootstrap-config.yaml
+++ b/charts/testkube-cloud-api/templates/bootstrap-config.yaml
@@ -39,13 +39,13 @@ data:
             {{- if .Values.api.features.bootstrapAdmin }}
             members:
               - email: {{.Values.api.features.bootstrapAdmin}}
-                role: admin
+                role: owner
             {{- end }}
         {{- end }}
         default_role: admin
         {{- if .Values.api.features.bootstrapAdmin }}
         members:
           - email: {{.Values.api.features.bootstrapAdmin}}
-            role: admin
+            role: owner
         {{- end }}
 {{- end }}


### PR DESCRIPTION
Checklist:

* [ ] Any new values are backwards compatible and/or have sensible default.
* [ ] I have signed off all my commits as required by [DCO](https://github.com/kubeshop/testkube-cloud-charts/blob/master/community/CONTRIBUTING.md).
* [ ] My CI is green.

<!-- Changes are automatically published when merged to `main`. They are not published on branches. -->