### PR TITLE
fix: testkube-cloud-api: change default invite mode to email

### DIFF
--- a/charts/testkube-cloud-api/values.yaml
+++ b/charts/testkube-cloud-api/values.yaml
@@ -145,7 +145,7 @@ api:
       enabled: false
       config: {}
   # -- Configure which invitation mode to use (email|auto-accept): email uses SMTP protocol to send email invites and auto-accept immediately adds them
-  inviteMode: auto-accept
+  inviteMode: email
   # email:
   #   fromEmail: "noreply@kubeshop.io"
   #   fromName: "Testkube Cloud"


### PR DESCRIPTION
Checklist:

* [ ] Any new values are backwards compatible and/or have sensible default.
* [ ] I have signed off all my commits as required by [DCO](https://github.com/kubeshop/testkube-cloud-charts/blob/master/community/CONTRIBUTING.md).
* [ ] My CI is green.

<!-- Changes are automatically published when merged to `main`. They are not published on branches. -->