### PR TITLE
fix: bootstrapUser config to use org owner role by default

### DIFF
--- a/charts/testkube-cloud-api/templates/bootstrap-config.yaml
+++ b/charts/testkube-cloud-api/templates/bootstrap-config.yaml
@@ -39,10 +39,10 @@ data:
             {{- if .Values.api.features.bootstrapAdmin }}
             members:
               - email: {{.Values.api.features.bootstrapAdmin}}
-                role: owner
+                role: admin
             {{- end }}
         {{- end }}
-        default_role: admin
+        default_role: owner
         {{- if .Values.api.features.bootstrapAdmin }}
         members:
           - email: {{.Values.api.features.bootstrapAdmin}}


### PR DESCRIPTION
Checklist:

* [ ] Any new values are backwards compatible and/or have sensible default.
* [ ] I have signed off all my commits as required by [DCO](https://github.com/kubeshop/testkube-cloud-charts/blob/master/community/CONTRIBUTING.md).
* [ ] My CI is green.

<!-- Changes are automatically published when merged to `main`. They are not published on branches. -->