### PR TITLE
feat: remove NGINX security headers from UI

### DIFF
--- a/charts/testkube-cloud-ui/templates/ingress-redirect.yaml
+++ b/charts/testkube-cloud-ui/templates/ingress-redirect.yaml
@@ -25,12 +25,6 @@ metadata:
     {{- if eq .Values.ingress.className "nginx"}}
     nginx.ingress.kubernetes.io/backend-protocol: "HTTP"
     nginx.ingress.kubernetes.io/preserve-trailing-slash: "true"
-    nginx.ingress.kubernetes.io/configuration-snippet: |
-      add_header X-Frame-Options "sameorigin";
-      add_header X-XSS-Protection "1; mode=block";
-      add_header X-Content-Type-Options nosniff;
-      add_header Referrer-Policy 'same-origin';
-      add_header Permissions-Policy "accelerometer=(), camera=(), geolocation=(), gyroscope=(), magnetometer=(), microphone=(), payment=(), usb=()";
     {{- end }}
     {{- if (eq .Values.global.certificateProvider "cert-manager") }}
     cert-manager.io/cluster-issuer: {{ required ".Values.global.certManager.issuerRef must be provided if provider is cert-manager" .Values.global.certManager.issuerRef }}

--- a/charts/testkube-cloud-ui/templates/ingress.yaml
+++ b/charts/testkube-cloud-ui/templates/ingress.yaml
@@ -25,12 +25,6 @@ metadata:
     {{- if eq .Values.ingress.className "nginx"}}
     nginx.ingress.kubernetes.io/backend-protocol: "HTTP"
     nginx.ingress.kubernetes.io/preserve-trailing-slash: "true"
-    nginx.ingress.kubernetes.io/configuration-snippet: |
-      add_header X-Frame-Options "sameorigin";
-      add_header X-XSS-Protection "1; mode=block";
-      add_header X-Content-Type-Options nosniff;
-      add_header Referrer-Policy 'same-origin';
-      add_header Permissions-Policy "accelerometer=(), camera=(), geolocation=(), gyroscope=(), magnetometer=(), microphone=(), payment=(), usb=()";
     {{- end }}
     {{- if (eq .Values.global.certificateProvider "cert-manager") }}
     cert-manager.io/cluster-issuer: {{ required ".Values.global.certManager.issuerRef must be provided if provider is cert-manager" .Values.global.certManager.issuerRef }}


### PR DESCRIPTION
Remove hardcoded NGINX security headers as that should be configured by customers based on their security preferences.

Also, the `configuration-snippet` annotation needs to be explicitly enabled in NGINX which causes more friction to customers.

Checklist:

* [ ] Any new values are backwards compatible and/or have sensible default.
* [ ] I have signed off all my commits as required by [DCO](https://github.com/kubeshop/testkube-cloud-charts/blob/master/community/CONTRIBUTING.md).
* [ ] My CI is green.

<!-- Changes are automatically published when merged to `main`. They are not published on branches. -->