### PR TITLE
feat: use forked multi-platform mongodb image, update charts

### DIFF
--- a/charts/testkube-enterprise/Chart.lock
+++ b/charts/testkube-enterprise/Chart.lock
@@ -19,12 +19,12 @@ dependencies:
   version: 0.18.0
 - name: mongodb
   repository: https://charts.bitnami.com/bitnami
-  version: 14.11.1
+  version: 15.6.16
 - name: nats
   repository: https://nats-io.github.io/k8s/helm/charts/
   version: 1.2.0
 - name: minio
   repository: file://./charts/minio
   version: 14.6.16
-digest: sha256:69d26e87a4ed62aadf65ba0faa79c49ac010f245efb8b4bfad9ba6abde30ec19
-generated: "2024-08-08T10:49:46.994667229Z"
+digest: sha256:ca0f826e613d30ebdb93606f8e90614d76344dc28562bfc8e6fb99421e577b8c
+generated: "2024-08-12T15:02:18.550814+02:00"

--- a/charts/testkube-enterprise/Chart.yaml
+++ b/charts/testkube-enterprise/Chart.yaml
@@ -26,7 +26,7 @@ dependencies:
     repository: file://./charts/dex
     condition: dex.enabled
   - name: mongodb
-    version: 14.11.1
+    version: 15.6.16
     repository: https://charts.bitnami.com/bitnami
     condition: mongodb.enabled
   - name: nats

--- a/charts/testkube-enterprise/profiles/values.demo.yaml
+++ b/charts/testkube-enterprise/profiles/values.demo.yaml
@@ -81,12 +81,6 @@ nats:
     cluster:
       enabled: false
 
-mongodb:
-  image:
-    registry: docker.io
-    repository: zcube/bitnami-compat-mongodb
-    tag: 6.0.5
-
 minio:
   auth:
     existingSecret: testkube-minio-credentials

--- a/charts/testkube-enterprise/values.yaml
+++ b/charts/testkube-enterprise/values.yaml
@@ -558,12 +558,15 @@ nats:
 mongodb:
   # -- Toggle whether to install MongoDB
   enabled: true
-  # Uncomment if you want to provide different image settings
-  # image:
-  # registry: docker.io
-  # repository: bitnami/mongodb
-  # tag: 7.0.3-debian-11-r6
-  # digest: ""
+
+  image:
+    registry: docker.io
+    # We have forked the Bitnami image as it did not support arm64, and the
+    # zcube/bitnami-compat-mongodb image that we previously used for the demo
+    # installer is unmaintained, stuck on Mongo 6, and incompatible with the
+    # latest Bitnami charts:
+    repository: kubeshop/bitnami-mongodb
+    tag: 7.0.12
 
   # -- MongoDB fullname override
   fullnameOverride: "testkube-enterprise-mongodb"


### PR DESCRIPTION
We have forked, https://github.com/kubeshop/bitnami-containers/pull/1,  the Bitnami image as it did not support arm64, and the
`zcube/bitnami-compat-mongodb` image that we previously used for the demo
installer is unmaintained, stuck on Mongo 6, and incompatible with the
latest Bitnami charts:

Checklist:

* [ ] Any new values are backwards compatible and/or have sensible default.
* [ ] I have signed off all my commits as required by [DCO](https://github.com/kubeshop/testkube-cloud-charts/blob/master/community/CONTRIBUTING.md).
* [ ] My CI is green.

<!-- Changes are automatically published when merged to `main`. They are not published on branches. -->