### PR TITLE
chore: cleanup dex config in profile and move common config to parent values yaml

### DIFF
--- a/charts/testkube-enterprise/profiles/values.demo.yaml
+++ b/charts/testkube-enterprise/profiles/values.demo.yaml
@@ -100,34 +100,13 @@ dex:
     enabled: true
   configTemplate:
     customConfig: ""
-    base: |
-      logger:
-        level: debug
-        format: json
-      web:
-        http: 0.0.0.0:5556
-      expiry:
-        deviceRequests: "5m"
-        signingKeys: "6h"
-        idTokens: "24h"
-        refreshTokens:
-          disableRotation: false
-          reuseInterval: "3s"
-          validIfNotUsedFor: "2160h" # 90 days
-          absoluteLifetime: "3960h" # 165 days
-      oauth2:
-        responseTypes: ["code"]
-        skipApprovalScreen: true
-        alwaysShowLoginScreen: false
-        passwordConnector: local
-    additionalStaticClients: []
-    additionalConfig: |
-      staticClients:
+    additionalStaticClients:
       - id: testkube-enterprise
         redirectURIs:
           - http://localhost:8090/auth/callback
         name: Testkube
         secret: QWkVzs3nct6HZM5hxsPzwaZtq
+    additionalConfig: |
       enablePasswordDB: true
       staticPasswords:
         - email: "admin@example.com"

--- a/charts/testkube-enterprise/templates/dex-config-secret.yaml
+++ b/charts/testkube-enterprise/templates/dex-config-secret.yaml
@@ -14,8 +14,8 @@ stringData:
   config.yaml: |-
     {{- .Values.dex.configTemplate.base | nindent 4 }}
     storage:
-      {{- if .Values.dex.storage }}
-      {{- toYaml .Values.dex.storage | nindent 6 }}
+      {{- with .Values.dex.storage }}
+      {{- toYaml . | nindent 6 }}
       {{- else }}
         type: kubernetes
         config:
@@ -34,11 +34,11 @@ stringData:
         secret: '{{ $api.api.oauth.clientSecret }}'
         redirectURIs:
           - '{{ if .Values.global.domain }}https://{{ .Values.global.restApiSubdomain }}.{{ .Values.global.domain }}/auth/callback{{ else }}http://localhost:8090/auth/callback{{ end }}'
-      {{- if .Values.dex.configTemplate.additionalStaticClients }}
-      {{- toYaml .Values.dex.configTemplate.additionalStaticClients | nindent 6 }}
+      {{- with .Values.dex.configTemplate.additionalStaticClients }}
+      {{- toYaml . | nindent 6 }}
       {{- end }}
-    {{- if .Values.dex.configTemplate.additionalConfig }}
-    {{ .Values.dex.configTemplate.additionalConfig | nindent 4 }}
+    {{- with .Values.dex.configTemplate.additionalConfig }}
+    {{ . | nindent 4 }}
     {{- end }}
   {{- end }}
 {{- end }}

--- a/charts/testkube-enterprise/values.yaml
+++ b/charts/testkube-enterprise/values.yaml
@@ -645,6 +645,22 @@ dex:
       logger:
         level: debug
         format: json
+      web:
+        http: 0.0.0.0:5556
+      expiry:
+        deviceRequests: "5m"
+        signingKeys: "6h"
+        idTokens: "24h"
+        refreshTokens:
+          disableRotation: false
+          reuseInterval: "3s"
+          validIfNotUsedFor: "2160h" # 90 days
+          absoluteLifetime: "3960h" # 165 days
+      oauth2:
+        responseTypes: ["code"]
+        skipApprovalScreen: true
+        alwaysShowLoginScreen: false
+        passwordConnector: local
     # -- Additional static clients which will be appended to the dex staticClients config
     additionalStaticClients: []
     #  - id: testkube-cloud-local


### PR DESCRIPTION
Fix issue where `staticClients` block is duplicated in Dex.

Move base Dex settings from demo profile to parent values.yaml

Add setting to skip additional Dex approval screen.

Checklist:

* [x] Any new values are backwards compatible and/or have sensible default.
* [ ] I have signed off all my commits as required by [DCO](https://github.com/kubeshop/testkube-cloud-charts/blob/master/community/CONTRIBUTING.md).
* [ ] My CI is green.

<!-- Changes are automatically published when merged to `main`. They are not published on branches. -->