### PR TITLE
fix: set ttlSeconds after finished for migrations to default 4 days t…

### DIFF
--- a/charts/testkube-cloud-api/README.md
+++ b/charts/testkube-cloud-api/README.md
@@ -58,7 +58,7 @@ A Helm chart for Testkube Cloud API
 | api.logServer.secure | string | `"false"` | Log server TLS configuration secure connection |
 | api.logServer.skipVerify | string | `"true"` | Log server TLS configuration skip Verify |
 | api.migrations.enabled | bool | `false` | Toggle whether to apply migrations for MongoDB |
-| api.migrations.ttlSecondsAfterFinished | int | `259200` | TTL for the migration job, defaults to 3 days |
+| api.migrations.ttlSecondsAfterFinished | int | `345600` | TTL for the migration job, defaults to 4 days |
 | api.migrations.useHelmHooks | bool | `true` | Toggle whether to enable pre-install & pre-upgrade hooks |
 | api.minio.accessKeyId | string | `""` | MinIO access key id |
 | api.minio.certSecret.baseMountPath | string | `"/etc/client-certs/storage"` | Base path to mount the client certificate secret |

--- a/charts/testkube-cloud-api/values.yaml
+++ b/charts/testkube-cloud-api/values.yaml
@@ -168,8 +168,8 @@ api:
     enabled: false
     # -- Toggle whether to enable pre-install & pre-upgrade hooks
     useHelmHooks: true
-    # -- TTL for the migration job, defaults to 3 days
-    ttlSecondsAfterFinished: 259200
+    # -- TTL for the migration job, defaults to 4 days
+    ttlSecondsAfterFinished: 345600
   features:
     # -- Toggle whether to disable personal organizations when a user signs up for the first time
     disablePersonalOrgs: false

--- a/charts/testkube-enterprise/README.md
+++ b/charts/testkube-enterprise/README.md
@@ -194,7 +194,7 @@ A Helm chart for Testkube Enterprise
 | testkube-cloud-api.api.logServer.skipVerify | string | `"true"` | Log server TLS configuration skip Verify |
 | testkube-cloud-api.api.migrations.enabled | bool | `true` | Toggle whether to run database migrations |
 | testkube-cloud-api.api.migrations.image.repository | string | `"kubeshop/testkube-enterprise-api-migrations"` | Migrations image repository |
-| testkube-cloud-api.api.migrations.ttlSecondsAfterFinished | int | `259200` | TTL for the migration job, defaults to 3 days |
+| testkube-cloud-api.api.migrations.ttlSecondsAfterFinished | int | `345600` | TTL for the migration job, defaults to 4 days |
 | testkube-cloud-api.api.migrations.useHelmHooks | bool | `false` | Toggle whether to enable pre-install & pre-upgrade hooks (should be disabled if mongo is installed using this chart) |
 | testkube-cloud-api.api.minio.certSecret.baseMountPath | string | `"/etc/client-certs/storage"` | Base path to mount the client certificate secret |
 | testkube-cloud-api.api.minio.certSecret.caFile | string | `"ca.crt"` | Path to ca file (used for self-signed certificates) |

--- a/charts/testkube-enterprise/values.yaml
+++ b/charts/testkube-enterprise/values.yaml
@@ -313,8 +313,8 @@ testkube-cloud-api:
         # -- Migrations image repository
         repository: kubeshop/testkube-enterprise-api-migrations
         # -- don't clean up finished jobs (pass value in seconds to clean migrations job after completenes)
-      # -- TTL for the migration job, defaults to 3 days
-      ttlSecondsAfterFinished: 259200
+      # -- TTL for the migration job, defaults to 4 days
+      ttlSecondsAfterFinished: 345600
     mongo: *global_mongo_config
     nats: *global_nats_config
     minio:

--- a/charts/testkube-enterprise/values.yaml
+++ b/charts/testkube-enterprise/values.yaml
@@ -312,7 +312,6 @@ testkube-cloud-api:
       image:
         # -- Migrations image repository
         repository: kubeshop/testkube-enterprise-api-migrations
-        # -- don't clean up finished jobs (pass value in seconds to clean migrations job after completenes)
       # -- TTL for the migration job, defaults to 4 days
       ttlSecondsAfterFinished: 345600
     mongo: *global_mongo_config


### PR DESCRIPTION
…o handle weekend windows

Checklist:

* [ ] Any new values are backwards compatible and/or have sensible default.
* [ ] I have signed off all my commits as required by [DCO](https://github.com/kubeshop/testkube-cloud-charts/blob/master/community/CONTRIBUTING.md).
* [ ] My CI is green.

<!-- Changes are automatically published when merged to `main`. They are not published on branches. -->