### PR TITLE
fix: remove version label

### DIFF
--- a/charts/testkube-cloud-api/templates/_helpers.tpl
+++ b/charts/testkube-cloud-api/templates/_helpers.tpl
@@ -34,7 +34,9 @@ Create chart name and version as used by the chart label.
 Common Testkube labels
 */}}
 {{- define "testkube-cloud-api.labels" -}}
+{{- if not (.Values.global.noVersionLabel | default false) }}
 app.kubernetes.io/version: {{ .Values.image.tag | quote }}
+{{- end }}
 app.kubernetes.io/component: backend
 {{ include "testkube-cloud-api.selectorLabels" . }}
 {{ include "testkube-cloud-api.baseLabels" . }}

--- a/charts/testkube-cloud-ui/templates/_helpers.tpl
+++ b/charts/testkube-cloud-ui/templates/_helpers.tpl
@@ -36,7 +36,9 @@ Common labels
 {{- define "testkube-cloud-ui.labels" -}}
 helm.sh/chart: {{ include "testkube-cloud-ui.chart" . }}
 {{ include "testkube-cloud-ui.selectorLabels" . }}
+{{- if not (.Values.global.noVersionLabel | default false) }}
 app.kubernetes.io/version: {{ .Values.image.tag | quote }}
+{{- end}}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
 app.kubernetes.io/component: frontend
 app.kubernetes.io/part-of: testkube-{{ if .Values.global.enterpriseMode }}enterprise{{ else }}cloud{{ end }}

--- a/charts/testkube-logs-service/templates/_helpers.tpl
+++ b/charts/testkube-logs-service/templates/_helpers.tpl
@@ -34,7 +34,9 @@ Create chart name and version as used by the chart label.
 Common Testkube labels
 */}}
 {{- define "testkube-log-service.labels" -}}
+{{- if not (.Values.global.noVersionLabel | default false) }}
 app.kubernetes.io/version: {{ .Values.image.tag | quote }}
+{{- end }}
 app.kubernetes.io/component: backend
 {{ include "testkube-log-service.selectorLabels" . }}
 {{ include "testkube-log-service.baseLabels" . }}

--- a/charts/testkube-worker-service/templates/_helpers.tpl
+++ b/charts/testkube-worker-service/templates/_helpers.tpl
@@ -34,7 +34,9 @@ Create chart name and version as used by the chart label.
 Common Testkube labels
 */}}
 {{- define "testkube-worker-service.labels" -}}
+{{- if not (.Values.global.noVersionLabel | default false) }}
 app.kubernetes.io/version: {{ .Values.image.tag | quote }}
+{{- end }}
 app.kubernetes.io/component: backend
 {{ include "testkube-worker-service.selectorLabels" . }}
 {{ include "testkube-worker-service.baseLabels" . }}


### PR DESCRIPTION
Skaffold's uses image tags which are longer than 63 characters which is a prohibited length for Kubernetes labels. This allows disabling adding those labels.