### PR TITLE
fix: [TKC-2561] add proxy * timeout options for REST ingress

### DIFF
--- a/charts/testkube-cloud-api/templates/ingress-rest.yaml
+++ b/charts/testkube-cloud-api/templates/ingress-rest.yaml
@@ -25,6 +25,11 @@ metadata:
     nginx.ingress.kubernetes.io/force-ssl-redirect: "true"
     nginx.ingress.kubernetes.io/preserve-trailing-slash: "true"
     nginx.ingress.kubernetes.io/backend-protocol: {{ if .Values.api.tls.serveHTTPS }}HTTPS{{ else }}HTTP{{ end }}
+    nginx.ingress.kubernetes.io/client-header-timeout: "10800"
+    nginx.ingress.kubernetes.io/client-body-timeout: "10800"
+    nginx.ingress.kubernetes.io/proxy-send-timeout: "10800"
+    nginx.ingress.kubernetes.io/proxy-read-timeout: "10800"
+    nginx.ingress.kubernetes.io/proxy-connect-timeout: "10800"
     {{- if and (not .Values.api.tls.serveHTTPS) (eq .Values.global.certificateProvider "cert-manager") }}
     cert-manager.io/cluster-issuer: {{ required ".Values.global.certManager.issuerRef must be provided if provider is cert-manager" .Values.global.certManager.issuerRef }}
     {{- end }}


### PR DESCRIPTION
Adding timeout options for REST cloud API.

Looks like cli connects to our API using HTTP SSE for logs stream, which gets killed by NGINX if there is a longer period without new events.

I've reproduced it by running locally with cypress / playwright tests where it takes a minute to pull an image and the logs stream gets broken because no new message arrives in 30s.



Checklist:

* [x] Any new values are backwards compatible and/or have sensible default.
* [x] I have signed off all my commits as required by [DCO](https://github.com/kubeshop/testkube-cloud-charts/blob/master/community/CONTRIBUTING.md).
* [ ] My CI is green.

<!-- Changes are automatically published when merged to `main`. They are not published on branches. -->