### PR TITLE
fix: do not pin the worker service in the demo

### DIFF
--- a/charts/testkube-enterprise/profiles/values.demo.yaml
+++ b/charts/testkube-enterprise/profiles/values.demo.yaml
@@ -75,8 +75,6 @@ testkube-agent:
 testkube-worker-service:
   additionalEnv:
     USE_MINIO: true
-  image:
-    tag: 1.9.6
 
 nats:
   config:


### PR DESCRIPTION
That image does not seem to have an arm variant.

Checklist:

* [ ] Any new values are backwards compatible and/or have sensible default.
* [ ] I have signed off all my commits as required by [DCO](https://github.com/kubeshop/testkube-cloud-charts/blob/master/community/CONTRIBUTING.md).
* [ ] My CI is green.

<!-- Changes are automatically published when merged to `main`. They are not published on branches. -->