### PR TITLE
fix: disable nats prometheus exporter by default

### DIFF
--- a/charts/testkube-enterprise/values.yaml
+++ b/charts/testkube-enterprise/values.yaml
@@ -568,7 +568,7 @@ nats:
   # Exporter container settings
   promExporter:
     # -- Toggle whether to install NATS exporter
-    enabled: true
+    enabled: false
     # Uncomment if you want to provide a different image or pullPolicy
     # image:
     # repository: natsio/prometheus-nats-exporter


### PR DESCRIPTION
Checklist:

* [ ] Any new values are backwards compatible and/or have sensible default.
* [ ] I have signed off all my commits as required by [DCO](https://github.com/kubeshop/testkube-cloud-charts/blob/master/community/CONTRIBUTING.md).
* [ ] My CI is green.

<!-- Changes are automatically published when merged to `main`. They are not published on branches. -->