### PR TITLE
fix: [TKC-2802] add redirect uri

### DIFF
--- a/charts/testkube-enterprise/profiles/values.demo.yaml
+++ b/charts/testkube-enterprise/profiles/values.demo.yaml
@@ -107,6 +107,7 @@ dex:
       - id: testkube-enterprise
         redirectURIs:
           - http://localhost:8090/auth/callback
+          - http://localhost:38090/auth/callback          
         name: Testkube
         secret: QWkVzs3nct6HZM5hxsPzwaZtq
     additionalConfig: |

--- a/charts/testkube-enterprise/templates/dex-config-secret.yaml
+++ b/charts/testkube-enterprise/templates/dex-config-secret.yaml
@@ -29,11 +29,13 @@ stringData:
         secret: '{{ $api.api.oauth.clientSecret }}'
         redirectURIs:
           - '{{ if .Values.global.domain }}https://{{ .Values.global.restApiSubdomain }}.{{ .Values.global.domain }}/auth/callback{{ else }}http://localhost:8090/auth/callback{{ end }}'
+          - '{{ if .Values.global.domain }}https://{{ .Values.global.restApiSubdomain }}.{{ .Values.global.domain }}/auth/callback{{ else }}http://localhost:38090/auth/callback{{ end }}'
       - id: teskube-cloud-cli
         name: 'Testkube Enterprise CLI'
         secret: '{{ $api.api.oauth.clientSecret }}'
         redirectURIs:
           - '{{ if .Values.global.domain }}https://{{ .Values.global.restApiSubdomain }}.{{ .Values.global.domain }}/auth/callback{{ else }}http://localhost:8090/auth/callback{{ end }}'
+          - '{{ if .Values.global.domain }}https://{{ .Values.global.restApiSubdomain }}.{{ .Values.global.domain }}/auth/callback{{ else }}http://localhost:38090/auth/callback{{ end }}' 
       {{- with .Values.dex.configTemplate.additionalStaticClients }}
       {{- toYaml . | nindent 6 }}
       {{- end }}

--- a/charts/testkube-enterprise/templates/dex-config-secret.yaml
+++ b/charts/testkube-enterprise/templates/dex-config-secret.yaml
@@ -28,14 +28,22 @@ stringData:
         name: 'Testkube Enterprise'
         secret: '{{ $api.api.oauth.clientSecret }}'
         redirectURIs:
-          - '{{ if .Values.global.domain }}https://{{ .Values.global.restApiSubdomain }}.{{ .Values.global.domain }}/auth/callback{{ else }}http://localhost:8090/auth/callback{{ end }}'
-          - '{{ if .Values.global.domain }}https://{{ .Values.global.restApiSubdomain }}.{{ .Values.global.domain }}/auth/callback{{ else }}http://localhost:38090/auth/callback{{ end }}'
+        {{- if .Values.global.domain }}
+          - 'https://{{ .Values.global.restApiSubdomain }}.{{ .Values.global.domain }}/auth/callback'
+        {{- else }}
+          - 'http://localhost:8090/auth/callback'
+          - 'http://localhost:38090/auth/callback'
+        {{- end }}
       - id: teskube-cloud-cli
         name: 'Testkube Enterprise CLI'
         secret: '{{ $api.api.oauth.clientSecret }}'
         redirectURIs:
-          - '{{ if .Values.global.domain }}https://{{ .Values.global.restApiSubdomain }}.{{ .Values.global.domain }}/auth/callback{{ else }}http://localhost:8090/auth/callback{{ end }}'
-          - '{{ if .Values.global.domain }}https://{{ .Values.global.restApiSubdomain }}.{{ .Values.global.domain }}/auth/callback{{ else }}http://localhost:38090/auth/callback{{ end }}' 
+        {{- if .Values.global.domain }}
+          - 'https://{{ .Values.global.restApiSubdomain }}.{{ .Values.global.domain }}/auth/callback'
+        {{- else }}
+          - 'http://localhost:8090/auth/callback'
+          - 'http://localhost:38090/auth/callback'
+        {{- end }} 
       {{- with .Values.dex.configTemplate.additionalStaticClients }}
       {{- toYaml . | nindent 6 }}
       {{- end }}

--- a/charts/testkube-enterprise/values.yaml
+++ b/charts/testkube-enterprise/values.yaml
@@ -728,6 +728,7 @@ dex:
     #    name: Testkube Cloud - localdev
     #    redirectURIs:
     #      - http://localhost:8090/auth/callback
+    #      - http://localhost:38090/auth/callback    
     #    secret: some-secret
     # -- Additional config which will be appended to the config like `staticClients`, `staticPasswords ,`connectors`...
     additionalConfig: ""


### PR DESCRIPTION
Add dex redirect uri for 38090 port

Checklist:

* [ ] Any new values are backwards compatible and/or have sensible default.
* [ ] I have signed off all my commits as required by [DCO](https://github.com/kubeshop/testkube-cloud-charts/blob/master/community/CONTRIBUTING.md).
* [ ] My CI is green.

<!-- Changes are automatically published when merged to `main`. They are not published on branches. -->