### PR TITLE
feat(TKC-2844): allow to specify/auto-generate master password for credentails storage

### DIFF
--- a/charts/testkube-cloud-api/README.md
+++ b/charts/testkube-cloud-api/README.md
@@ -129,6 +129,10 @@ A Helm chart for Testkube Cloud API
 | global.certManager.issuerRef | string | `""` | Certificate Issuer ref (only used if `provider` is set to `cert-manager`) |
 | global.certificateProvider | string | `""` | TLS provider (possible values: "", "cert-manager") |
 | global.containerSecurityContext | object | `{}` | Global security Context for all containers |
+| global.credentials.masterPassword.secretKeyRef | object | `{"key":"password","name":""}` | Reference to the master password stored in the Secret |
+| global.credentials.masterPassword.secretKeyRef.key | string | `"password"` | Secret key |
+| global.credentials.masterPassword.secretKeyRef.name | string | `""` | Secret name |
+| global.credentials.masterPassword.value | string | `""` | Plain-text master password |
 | global.customCaSecretKey | string | `"ca.crt"` | Custom CA to use as a trusted CA during TLS connections. Specify a key for the secret specified under customCaSecretRef. |
 | global.customCaSecretRef | string | `""` | Custom CA to use as a trusted CA during TLS connections. Specify a secret with the PEM encoded CA under the key specified by customCaSecretKey. |
 | global.dex.issuer | string | `""` | Global Dex issuer url |

--- a/charts/testkube-cloud-api/templates/deployment.yaml
+++ b/charts/testkube-cloud-api/templates/deployment.yaml
@@ -319,6 +319,15 @@ spec:
             - name: OUTPUTS_BUCKET
               value: "{{ $outputsBucket }}"
             {{- $minioEndpoint := .Values.global.storage.endpoint | default .Values.api.minio.endpoint }}
+            - name: CREDENTIALS_MASTER_PASSWORD
+              {{- if .Values.global.credentials.masterPassword.secretKeyRef.name }}
+              valueFrom:
+                secretKeyRef:
+                  key: {{ .Values.global.credentials.masterPassword.secretKeyRef.key | default "password" }}
+                  name: {{ .Values.global.credentials.masterPassword.secretKeyRef.name }}
+              {{- else }}
+              value: "{{ .Values.global.credentials.masterPassword.value }}"
+              {{- end }}
             - name: MINIO_ENDPOINT
               value: "{{ tpl $minioEndpoint . }}"
             {{- $minioRegion := .Values.global.storage.region | default .Values.api.minio.region }}

--- a/charts/testkube-cloud-api/values.yaml
+++ b/charts/testkube-cloud-api/values.yaml
@@ -90,6 +90,19 @@ global:
       endpoint: ""
       # -- Toggle whether to use HTTPS when connecting to the public S3 server
       secure: null
+  ## -- Configuration for the encrypted Credentials storage
+  credentials:
+    ## -- Master password to use for deriving encryption key
+    masterPassword:
+      # -- Reference to the master password stored in the Secret
+      secretKeyRef:
+        # -- Secret name
+        name: ""
+        # -- Secret key
+        key: "password"
+      # -- Plain-text master password
+      value: ""
+
   tls: {}
   # -- Toggle whether to globally skip certificate verification
   #skipVerify: false

--- a/charts/testkube-enterprise/README.md
+++ b/charts/testkube-enterprise/README.md
@@ -57,6 +57,10 @@ A Helm chart for Testkube Enterprise
 | global.certManager.issuerRef | string | `""` | Certificate Issuer ref (only used if `provider` is set to `cert-manager`) |
 | global.certificateProvider | string | `"cert-manager"` | TLS certificate provider. Set to "cert-manager" for integration with cert-manager or leave empty for other methods |
 | global.containerSecurityContext | object | `{}` | Global security Context for all containers. |
+| global.credentials.masterPassword.secretKeyRef | object | `{"key":"password","name":""}` | Reference to the master password stored in the Secret |
+| global.credentials.masterPassword.secretKeyRef.key | string | `"password"` | Secret key |
+| global.credentials.masterPassword.secretKeyRef.name | string | `""` | Secret name |
+| global.credentials.masterPassword.value | string | `""` | Plain-text master password |
 | global.customCaSecretKey | string | `"ca.crt"` | Custom CA to use as a trusted CA during TLS connections. Specify a key for the secret specified under customCaSecretRef. |
 | global.customCaSecretRef | string | `""` | Custom CA to use as a trusted CA during TLS connections. Specify a secret with the PEM encoded CA under the key specified by customCaSecretKey. |
 | global.dex.issuer | string | `""` | Global Dex issuer url which is configured both in Dex and API |

--- a/charts/testkube-enterprise/profiles/values.demo.yaml
+++ b/charts/testkube-enterprise/profiles/values.demo.yaml
@@ -11,6 +11,10 @@ global:
       secure: false
     credsSecretRef: testkube-minio-credentials
     secure: false
+  credentials:
+    masterPassword:
+      secretKeyRef:
+        name: testkube-credentials-master
 
 sharedSecretGenerator:
   enabled: true

--- a/charts/testkube-enterprise/templates/shared-secrets/configmap.yaml
+++ b/charts/testkube-enterprise/templates/shared-secrets/configmap.yaml
@@ -50,4 +50,5 @@ data:
     # TestKube Default Agent Token
     generate_secret_if_needed "testkube-default-agent-token" --from-literal=agent-token=tkcagnt_$(gen_random 'a-f0-9' 16)
     generate_secret_if_needed "testkube-minio-credentials" --from-literal=root-user=testkube-enterprise --from-literal=root-password=$(gen_random 'a-zA-Z0-9' 16) --from-literal=token=""
+    generate_secret_if_needed "testkube-credentials-master" --from-literal=password=$(gen_random 'a-zA-Z0-9' 32)
 {{- end}}

--- a/charts/testkube-enterprise/values.yaml
+++ b/charts/testkube-enterprise/values.yaml
@@ -90,6 +90,18 @@ global:
       endpoint: ""
       # -- Toggle whether to use HTTPS when connecting to the public S3 server
       secure: null
+  ## -- Configuration for the encrypted Credentials storage
+  credentials:
+    ## -- Master password to use for deriving encryption key
+    masterPassword:
+      # -- Reference to the master password stored in the Secret
+      secretKeyRef:
+        # -- Secret name
+        name: ""
+        # -- Secret key
+        key: "password"
+      # -- Plain-text master password
+      value: ""
   tls: {}
   # -- Toggle whether to globally skip certificate verification
   #skipVerify: true


### PR DESCRIPTION
https://github.com/kubeshop/testkube-cloud-api/pull/1633

Checklist:

* [ ] Any new values are backwards compatible and/or have sensible default.
* [ ] I have signed off all my commits as required by [DCO](https://github.com/kubeshop/testkube-cloud-charts/blob/master/community/CONTRIBUTING.md).
* [ ] My CI is green.