### PR TITLE
feat: add an option to disable mongo init container for Worker service

### DIFF
--- a/charts/testkube-enterprise/values.yaml
+++ b/charts/testkube-enterprise/values.yaml
@@ -500,6 +500,8 @@ testkube-worker-service:
     readOnlyRootFilesystem: true
   # -- Mongo Init Container values
   init:
+    # -- Toggle whether to enable the dependency check containers
+    enabled: false
     mongo:
       image:
         # -- MongoSH image registry

--- a/charts/testkube-worker-service/templates/deployment.yaml
+++ b/charts/testkube-worker-service/templates/deployment.yaml
@@ -29,6 +29,7 @@ spec:
       {{- end }}
       serviceAccountName: {{ include "testkube-worker-service.serviceAccountName" . }}
       securityContext: {{ include "testkube-worker-service.podSecurityContext" . | nindent 8 }}
+      {{- if .Values.init.enabled }}
       initContainers:
         - name: wait-for-mongo
           image: {{ include "testkube-worker.init-mongo-image" . }}
@@ -51,6 +52,7 @@ spec:
               {{- else }}
               value: {{ .Values.global.mongo.dsn | default .Values.api.mongo.dsn }}
               {{- end }}
+      {{- end }}
       containers:
         - name: {{ .Chart.Name }}
           securityContext: {{ include "testkube-worker-service.containerSecurityContext" . | nindent 12 }}

--- a/charts/testkube-worker-service/values.yaml
+++ b/charts/testkube-worker-service/values.yaml
@@ -74,6 +74,8 @@ additionalEnv: {}
 
 # -- Mongo Init Container values
 init:
+  # -- Toggle whether to enable the dependency check containers
+  enabled: false
   mongo:
     image:
       # -- MongoSH image registry


### PR DESCRIPTION
Checklist:

* [ ] Any new values are backwards compatible and/or have sensible default.
* [ ] I have signed off all my commits as required by [DCO](https://github.com/kubeshop/testkube-cloud-charts/blob/master/community/CONTRIBUTING.md).
* [ ] My CI is green.

<!-- Changes are automatically published when merged to `main`. They are not published on branches. -->