### PR TITLE
fix: [TKC-3037] Fix allow demo port-forwarding on any localhost port

### DIFF
--- a/charts/testkube-enterprise/profiles/values.demo.yaml
+++ b/charts/testkube-enterprise/profiles/values.demo.yaml
@@ -49,6 +49,7 @@ testkube-cloud-api:
       clientSecret: "QWkVzs3nct6HZM5hxsPzwaZtq"
       redirectUri: "http://localhost:8090/auth/callback"
       issuerUrl: ""
+      allowedExternalRedirectURIs: "http://localhost:*"
     dashboardAddress: "http://localhost:8080"
     apiAddress: "http://localhost:8090"
     outputsBucket: testkube-cloud-outputs


### PR DESCRIPTION
One POC user had an issue with tk demo init


> {"level":"warn","ts":"2024-12-31T08:59:26Z","caller":"httputil/writers.go:97","msg":"forbidden redirect URL: [http://localhost:8081/auth/success","version":"1.10.95","build":"enterprise","httpMethod":"GET","httpPath":"/auth/callback","requestId":"9590ddac-8a15-4d29-84be-9b80f6d48a10","sub":"","error":"forbidden](http://localhost:8081/auth/success%22,%22version%22:%221.10.95%22,%22build%22:%22enterprise%22,%22httpMethod%22:%22GET%22,%22httpPath%22:%22/auth/callback%22,%22requestId%22:%229590ddac-8a15-4d29-84be-9b80f6d48a10%22,%22sub%22:%22%22,%22error%22:%22forbidden) redirect URL: http://localhost:8081/auth/success"}

Because he port-forward on 8081 instead of 8080, this change allows all localhost ports.