### PR TITLE
fix: bump testkube chart in enterprise

### DIFF
--- a/charts/testkube-enterprise/Chart.yaml
+++ b/charts/testkube-enterprise/Chart.yaml
@@ -20,7 +20,7 @@ dependencies:
     repository: file://../testkube-worker-service
   - name: testkube
     alias: testkube-agent
-    version: 2.1.121
+    version: 2.1.122
     repository: https://kubeshop.github.io/helm-charts
     condition: testkube-agent.enabled
   - name: dex


### PR DESCRIPTION
Checklist:

* [ ] Any new values are backwards compatible and/or have sensible default.
* [ ] I have signed off all my commits as required by [DCO](https://github.com/kubeshop/testkube-cloud-charts/blob/master/community/CONTRIBUTING.md).
* [ ] My CI is green.

<!-- Changes are automatically published when merged to `main`. They are not published on branches. -->