### PR TITLE
feat: testkube-cloud-api: add support for additional env var references

### DIFF
--- a/charts/testkube-cloud-api/templates/deployment.yaml
+++ b/charts/testkube-cloud-api/templates/deployment.yaml
@@ -445,6 +445,9 @@ spec:
               value: "{{ .Values.scim.auth.token }}"
               {{- end }}
             {{- end }}
+            {{- with .Values.additionalEnvVars }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
           ports:
             - name: {{ if .Values.api.tls.serveHTTPS }}https{{ else }}http{{ end }}
               containerPort: {{ if .Values.api.tls.serveHTTPS }}{{ .Values.api.tls.apiPort }}{{ else }}8090{{ end }}

--- a/charts/testkube-cloud-api/values.yaml
+++ b/charts/testkube-cloud-api/values.yaml
@@ -133,9 +133,16 @@ migrationImage:
 imagePullSecrets: []
 nameOverride: ""
 fullnameOverride: ""
-# -- Additional env vars to be added to the deployment
+# -- Additional env vars to be added to the deployment, expects a map of envvar name to value.
 additionalEnv: {}
 # FOO: bar
+# -- Additional env vars to be added to the deployment, expects an array of EnvVar objects (supports name, value, valueFrom, etc.)
+additionalEnvVars: []
+# - name: FOO
+#   valueFrom:
+#     secretKeyRef:
+#       name: my-secret
+
 # -- Specifies the path to the directory (skip the trailing slash) where CA certificates should be mounted. The mounted file should container a PEM encoded CA certificate.
 customCaDirPath: ""
 # -- Specifies the path where the license key should be mounted.


### PR DESCRIPTION
Even though there exists a field called `additionalEnv`, it can only be used as a envvar->value map, but we need also a solution to add additional envvars from secrets. Also, the `additionalEnv` is already used internally and by customers so we cannot remove it easily.

The new field `additionalEnvVars` supports an array of EnvVar objects (name, value, valueFrom...)

Checklist:

* [x] Any new values are backwards compatible and/or have sensible default.
* [x] I have signed off all my commits as required by [DCO](https://github.com/kubeshop/testkube-cloud-charts/blob/master/community/CONTRIBUTING.md).
* [ ] My CI is green.

<!-- Changes are automatically published when merged to `main`. They are not published on branches. -->