### PR TITLE
fix: simplify and fix update charts workflow

### DIFF
--- a/.github/workflows/update-charts-dispatch.yaml
+++ b/.github/workflows/update-charts-dispatch.yaml
@@ -61,6 +61,7 @@ jobs:
           helm dependency update charts/testkube-enterprise
 
       - name: Sync & Update Testkube Enterprise Helm chart
+        if: github.event.action != 'trigger-workflow-testkube-agent-main'
         run: |
           echo "Syncing subchart versions in testkube-enterprise Helm chart"
           ./scripts/sync.sh


### PR DESCRIPTION
- simpler logic for the others steps
- agent chart is part of enterprise chart also

I looked into it after I noticed this strange update and an issue with the ai service step:
https://github.com/kubeshop/testkube-cloud-charts/commit/36fb24c57b6aa4b9e9bbd208f217a100fc9c7b60

Checklist:

* [ ] Any new values are backwards compatible and/or have sensible default.
* [ ] I have signed off all my commits as required by [DCO](https://github.com/kubeshop/testkube-cloud-charts/blob/master/community/CONTRIBUTING.md).
* [ ] My CI is green.

<!-- Changes are automatically published when merged to `main`. They are not published on branches. -->