### PR TITLE
chore: add extra env vars to ai service chart

### DIFF
--- a/charts/testkube-ai-service/templates/deployment.yaml
+++ b/charts/testkube-ai-service/templates/deployment.yaml
@@ -47,10 +47,12 @@ spec:
           env:
             - name: CONTROL_PLANE_ENDPOINT
               value: {{ if .Values.controlPlaneRestApiUri }}{{ .Values.controlPlaneRestApiUri }}{{ else }}https://{{ .Values.global.restApiSubdomain }}.{{ .Values.global.domain }}{{ end }}
+            - name: ENV
+              value: "{{ .Values.nodeEnv | default .Values.env | default "production" }}"
             - name: NODE_ENV
-              value: "{{ .Values.env }}"
+              value: "{{ .Values.nodeEnv | default .Values.env | default "production" }}"
             - name: LOG_LEVEL
-              value: "{{ .Values.logLevel }}"
+              value: "{{ .Values.logLevel | default "info" }}"
             - name: PORT
               value: "{{ .Values.service.port }}"
             {{ if and .Values.oauthIssuer .Values.oauthJwksUri }}

--- a/charts/testkube-ai-service/templates/deployment.yaml
+++ b/charts/testkube-ai-service/templates/deployment.yaml
@@ -95,6 +95,9 @@ spec:
             - name: SSL_CERT_DIR
               value: "{{ $certsDir }}"
             {{- end }}
+            {{- with .Values.additionalEnvVars }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
           ports:
             - name: {{ if .Values.tls.serveHTTPS }}https{{ else }}http{{ end }}
               containerPort: {{ .Values.service.port }}

--- a/charts/testkube-ai-service/values.yaml
+++ b/charts/testkube-ai-service/values.yaml
@@ -77,6 +77,10 @@ ingress:
   enabled: true
   className: "nginx"
   annotations: {}
+# -- Additional env vars to be added to the deployment, expects an array of EnvVar objects (supports name, value, valueFrom, etc.)
+additionalEnvVars: []
+# - name: HTTP_PROXY
+#   value: "http://proxy.domain:8080"
 resources: {}
 autoscaling:
   enabled: false

--- a/charts/testkube-ai-service/values.yaml
+++ b/charts/testkube-ai-service/values.yaml
@@ -95,8 +95,10 @@ affinity: {}
 host: ""
 # -- URI to Testkube's control plane REST API (e.g. https://api.testkube.io)
 controlPlaneRestApiUri: ""
-# -- Environment of deployment
+# -- Environment of deployment (DEPRECATED)
 env: "production"
+# -- Environment of deployment
+nodeEnv: "production"
 # -- Log level
 logLevel: "info"
 # -- Use OpenID Conect (OIDC) Discovery endpoint to fetch configurations from the identity provider. The path should end with `/.well-known/openid-configuration`.

--- a/charts/testkube-enterprise/values.yaml
+++ b/charts/testkube-enterprise/values.yaml
@@ -584,6 +584,7 @@ testkube-ai-service:
     enabled: true
     className: "nginx"
     annotations: {}
+  # -- Additional env vars to be added to the deployment, expects an array of EnvVar objects (supports name, value, valueFrom, etc.)
   additionalEnvVars: []
   resources: {}
   autoscaling:

--- a/charts/testkube-enterprise/values.yaml
+++ b/charts/testkube-enterprise/values.yaml
@@ -600,7 +600,7 @@ testkube-ai-service:
   # -- URI to Testkube's control plane REST API (e.g. https://api.testkube.io)
   controlPlaneRestApiUri: ""
   # -- Environment of deployment
-  env: "production"
+  nodeEnv: "production"
   # -- Log level
   logLevel: "info"
   # -- Use OpenID Connect (OIDC) Discovery URI to fetch configurations from the identity provider. The path should end with `/.well-known/openid-configuration`.

--- a/charts/testkube-enterprise/values.yaml
+++ b/charts/testkube-enterprise/values.yaml
@@ -584,6 +584,7 @@ testkube-ai-service:
     enabled: true
     className: "nginx"
     annotations: {}
+  additionalEnvVars: []
   resources: {}
   autoscaling:
     enabled: false


### PR DESCRIPTION
Checklist:

* [x] Any new values are backwards compatible and/or have sensible default.
* [x] I have signed off all my commits as required by [DCO](https://github.com/kubeshop/testkube-cloud-charts/blob/master/community/CONTRIBUTING.md).
* [x] My CI is green.

<!-- Changes are automatically published when merged to `main`. They are not published on branches. -->