### PR TITLE
feat: disable dex ingress if globals are also disabled

### DIFF
--- a/charts/testkube-enterprise/Chart.lock
+++ b/charts/testkube-enterprise/Chart.lock
@@ -19,7 +19,7 @@ dependencies:
   version: 2.1.151
 - name: dex
   repository: file://./charts/dex
-  version: 0.19.1-7
+  version: 0.19.1-8
 - name: mongodb
   repository: file://./charts/mongodb
   version: 16.2.1-1
@@ -29,5 +29,5 @@ dependencies:
 - name: minio
   repository: file://./charts/minio
   version: 14.8.3-2
-digest: sha256:0a2ae604be948f8f3105ddefda4c56dc0f6fd6470971217c723e4af45007cc8c
-generated: "2025-02-21T10:06:10.281220068Z"
+digest: sha256:721d7ce45c8f6c0df4e49db33b4f15ab1c762b3544591448ead7aa90061a1711
+generated: "2025-02-25T14:27:55.258839+02:00"

--- a/charts/testkube-enterprise/Chart.yaml
+++ b/charts/testkube-enterprise/Chart.yaml
@@ -28,7 +28,7 @@ dependencies:
     repository: https://kubeshop.github.io/helm-charts
     condition: testkube-agent.enabled
   - name: dex
-    version: 0.19.1-7
+    version: 0.19.1-8
     repository: file://./charts/dex
     condition: dex.enabled
   - name: mongodb

--- a/charts/testkube-enterprise/charts/dex/Chart.yaml
+++ b/charts/testkube-enterprise/charts/dex/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 type: application
 name: dex
-version: 0.19.1-7
+version: 0.19.1-8
 appVersion: "2.42.0"
 kubeVersion: ">=1.14.0-0"
 description: OpenID Connect (OIDC) identity and OAuth 2.0 provider with pluggable connectors.

--- a/charts/testkube-enterprise/charts/dex/templates/ingress.yaml
+++ b/charts/testkube-enterprise/charts/dex/templates/ingress.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.ingress.enabled -}}
+{{- if and .Values.global.ingress.enabled .Values.ingress.enabled -}}
 {{- $fullName := include "dex.fullname" . -}}
 {{- $svcPort := .Values.service.ports.http.port -}}
 {{- if and .Values.ingress.className (not (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion)) }}


### PR DESCRIPTION
Checklist:

* [ ] Any new values are backwards compatible and/or have sensible default.
* [ ] I have signed off all my commits as required by [DCO](https://github.com/kubeshop/testkube-cloud-charts/blob/master/community/CONTRIBUTING.md).
* [ ] My CI is green.

<!-- Changes are automatically published when merged to `main`. They are not published on branches. -->