### PR TITLE
feat: add additional annotations property for job secret-generator

### DIFF
--- a/charts/testkube-enterprise/templates/shared-secrets/job.yaml
+++ b/charts/testkube-enterprise/templates/shared-secrets/job.yaml
@@ -7,6 +7,9 @@ metadata:
   annotations:
     "helm.sh/hook": pre-install,pre-upgrade
     "helm.sh/hook-delete-policy": hook-succeeded,before-hook-creation
+    {{- with .Values.sharedSecretGenerator.annotations }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
 spec:
   template:
     spec:

--- a/charts/testkube-enterprise/values.yaml
+++ b/charts/testkube-enterprise/values.yaml
@@ -128,6 +128,8 @@ sharedSecretGenerator:
   securityContext: {}
   # -- Container Security Context for the Shared Secret Generator Job
   containerSecurityContext: {}
+  # -- Pod Annotations for the Shared Secret Generator Job
+  annotations: {}
   # -- Resources for the Shared Secret Generator Job
   resources: {}
   image:
@@ -962,3 +964,5 @@ dex:
           - "{{ .Values.global.restApiSubdomain }}.{{ .Values.global.domain }}"
 image:
   tag: 2.2.0
+
+  


### PR DESCRIPTION
Requested by customer Virta Health to be able to add Istio labels.

Checklist:

* [x] Any new values are backwards compatible and/or have sensible default.
* [x] I have signed off all my commits as required by [DCO](https://github.com/kubeshop/testkube-cloud-charts/blob/master/community/CONTRIBUTING.md).
* [x] My CI is green.

<!-- Changes are automatically published when merged to `main`. They are not published on branches. -->