### PR TITLE
fix: ai service chart was not building due a logic error

### DIFF
--- a/charts/testkube-ai-service/templates/deployment.yaml
+++ b/charts/testkube-ai-service/templates/deployment.yaml
@@ -69,13 +69,13 @@ spec:
               value: "{{ . }}"
               {{- end }}
             - name: LLM_API_KEY
-              {{- with .Values.llmApi.apiKey }}
-              value: "{{ . }}"
-              {{- else if .Values.llmApi.secretRef }}
+              {{- if .Values.llmApi.secretRef }}
               valueFrom:
                 secretKeyRef:
                   name: {{ .Values.llmApi.secretRef }}
                   key: LLM_API_KEY
+              {{- else }}
+              value: "{{ .Values.llmApi.apiKey }}"
               {{- end }}
             {{ if .Values.llmTracing.enabled }}
             - name: LLM_TRACING_API_KEY


### PR DESCRIPTION
Checklist:

* [x] Any new values are backwards compatible and/or have sensible default.
* [ ] I have signed off all my commits as required by [DCO](https://github.com/kubeshop/testkube-cloud-charts/blob/master/community/CONTRIBUTING.md).
* [ ] My CI is green.

<!-- Changes are automatically published when merged to `main`. They are not published on branches. -->