### PR TITLE
fix: set key for env name

### DIFF
--- a/charts/testkube-ai-service/templates/deployment.yaml
+++ b/charts/testkube-ai-service/templates/deployment.yaml
@@ -104,7 +104,7 @@ spec:
             - name: {{ $key }}
               valueFrom:
                 secretKeyRef:
-                  key: {{ $value }}
+                  key: {{ $key }}
                   name: ai-service-external-secrets
             {{ end }}
             {{- end}}


### PR DESCRIPTION
Checklist:

* [x] Any new values are backwards compatible and/or have sensible default.
* [x] I have signed off all my commits as required by [DCO](https://github.com/kubeshop/testkube-cloud-charts/blob/master/community/CONTRIBUTING.md).
* [x] My CI is green.

<!-- Changes are automatically published when merged to `main`. They are not published on branches. -->