### PR TITLE
fix: dex static client for CLI testkube typo

### DIFF
--- a/charts/testkube-enterprise/templates/dex-config-secret.yaml
+++ b/charts/testkube-enterprise/templates/dex-config-secret.yaml
@@ -34,7 +34,7 @@ stringData:
           - 'http://localhost:8090/auth/callback'
           - 'http://localhost:38090/auth/callback'
         {{- end }}
-      - id: teskube-cloud-cli
+      - id: testkube-cloud-cli
         name: 'Testkube Enterprise CLI'
         secret: '{{ $api.api.oauth.clientSecret }}'
         redirectURIs:


### PR DESCRIPTION
Checklist:

* [x] Any new values are backwards compatible and/or have sensible default.
* [x] I have signed off all my commits as required by [DCO](https://github.com/kubeshop/testkube-cloud-charts/blob/master/community/CONTRIBUTING.md).
* [ ] My CI is green.

<!-- Changes are automatically published when merged to `main`. They are not published on branches. -->