### PR TITLE
fix: allow Testkube Enterprise to redirect back to the Testkube CLI

### DIFF
--- a/charts/testkube-enterprise/templates/dex-config-secret.yaml
+++ b/charts/testkube-enterprise/templates/dex-config-secret.yaml
@@ -31,6 +31,7 @@ stringData:
         {{- if .Values.global.domain }}
           - 'https://{{ .Values.global.restApiSubdomain }}.{{ .Values.global.domain }}/auth/callback'
         {{- else }}
+          - 'http://localhost:8090/auth/callback'
           - 'http://localhost:38090/auth/callback'
         {{- end }}
       - id: testkube-cloud-cli

--- a/charts/testkube-enterprise/templates/dex-config-secret.yaml
+++ b/charts/testkube-enterprise/templates/dex-config-secret.yaml
@@ -28,7 +28,6 @@ stringData:
         name: 'Testkube Enterprise'
         secret: '{{ $api.api.oauth.clientSecret }}'
         redirectURIs:
-          - 'http://127.0.0.1:8090/callback'
         {{- if .Values.global.domain }}
           - 'https://{{ .Values.global.restApiSubdomain }}.{{ .Values.global.domain }}/auth/callback'
         {{- else }}
@@ -39,11 +38,6 @@ stringData:
         secret: '{{ $api.api.oauth.clientSecret }}'
         redirectURIs:
           - 'http://127.0.0.1:8090/callback'
-        {{- if .Values.global.domain }}
-          - 'https://{{ .Values.global.restApiSubdomain }}.{{ .Values.global.domain }}/auth/callback'
-        {{- else }}
-          - 'http://localhost:38090/auth/callback'
-        {{- end }} 
       {{- with .Values.dex.configTemplate.additionalStaticClients }}
       {{- toYaml . | nindent 6 }}
       {{- end }}

--- a/charts/testkube-enterprise/templates/dex-config-secret.yaml
+++ b/charts/testkube-enterprise/templates/dex-config-secret.yaml
@@ -28,20 +28,20 @@ stringData:
         name: 'Testkube Enterprise'
         secret: '{{ $api.api.oauth.clientSecret }}'
         redirectURIs:
+          - 'http://127.0.0.1:8090/callback'
         {{- if .Values.global.domain }}
           - 'https://{{ .Values.global.restApiSubdomain }}.{{ .Values.global.domain }}/auth/callback'
         {{- else }}
-          - 'http://localhost:8090/auth/callback'
           - 'http://localhost:38090/auth/callback'
         {{- end }}
       - id: testkube-cloud-cli
         name: 'Testkube Enterprise CLI'
         secret: '{{ $api.api.oauth.clientSecret }}'
         redirectURIs:
+          - 'http://127.0.0.1:8090/callback'
         {{- if .Values.global.domain }}
           - 'https://{{ .Values.global.restApiSubdomain }}.{{ .Values.global.domain }}/auth/callback'
         {{- else }}
-          - 'http://localhost:8090/auth/callback'
           - 'http://localhost:38090/auth/callback'
         {{- end }} 
       {{- with .Values.dex.configTemplate.additionalStaticClients }}


### PR DESCRIPTION
Checklist:

* [x] Any new values are backwards compatible and/or have sensible default.
* [x] I have signed off all my commits as required by [DCO](https://github.com/kubeshop/testkube-cloud-charts/blob/master/community/CONTRIBUTING.md).
* [x] My CI is green.

<!-- Changes are automatically published when merged to `main`. They are not published on branches. -->