### PR TITLE
fix: make the CLI Dex client public

### DIFF
--- a/charts/testkube-enterprise/templates/dex-config-secret.yaml
+++ b/charts/testkube-enterprise/templates/dex-config-secret.yaml
@@ -36,7 +36,7 @@ stringData:
         {{- end }}
       - id: testkube-cloud-cli
         name: 'Testkube Enterprise CLI'
-        secret: '{{ $api.api.oauth.clientSecret }}'
+        public: true
         redirectURIs:
           - 'http://127.0.0.1:8090/callback'
       {{- with .Values.dex.configTemplate.additionalStaticClients }}


### PR DESCRIPTION
Checklist:

* [x] Any new values are backwards compatible and/or have sensible default.
* [x] I have signed off all my commits as required by [DCO](https://github.com/kubeshop/testkube-cloud-charts/blob/master/community/CONTRIBUTING.md).
* [x] My CI is green.

<!-- Changes are automatically published when merged to `main`. They are not published on branches. -->