### PR TITLE
fix: provide correct agent host/port for demo profile

### DIFF
--- a/charts/testkube-enterprise/profiles/values.demo.yaml
+++ b/charts/testkube-enterprise/profiles/values.demo.yaml
@@ -39,8 +39,8 @@ testkube-cloud-api:
       bootstrapEnv: "my-first-environment"
       bootstrapAgentTokenSecretRef: "testkube-default-agent-token"
     agent:
-      host: "testkube-enterprise-api:grpcs"
-      port: 80
+      host: "testkube-enterprise-api"
+      port: 8089
     tls:
       serveHTTPS: false
     oauth:


### PR DESCRIPTION
Checklist:

* [x] Any new values are backwards compatible and/or have sensible default.
* [x] I have signed off all my commits as required by [DCO](https://github.com/kubeshop/testkube-cloud-charts/blob/master/community/CONTRIBUTING.md).
* [x] My CI is green.

<!-- Changes are automatically published when merged to `main`. They are not published on branches. -->