### PR TITLE
feat: TKC-3519: add support for dex api url in testkube-cloud-api

### DIFF
--- a/charts/testkube-cloud-api/templates/deployment.yaml
+++ b/charts/testkube-cloud-api/templates/deployment.yaml
@@ -457,6 +457,10 @@ spec:
             - name: GITHUB_PRIVATE_KEY_FILE
               value: {{ . | quote }}
             {{- end }}
+            {{- if .Values.api.dex.grpc.host }}
+            - name: DEX_GRPC_API_URL
+              value: "{{ .Values.api.dex.grpc.host }}:{{ .Values.api.dex.grpc.port }}"
+            {{- end }}
             {{- with .Values.additionalEnvVars }}
             {{- toYaml . | nindent 12 }}
             {{- end }}

--- a/charts/testkube-cloud-api/values.yaml
+++ b/charts/testkube-cloud-api/values.yaml
@@ -201,6 +201,12 @@ scim:
     # -- Secret ref for SCIM server authentication (secret must contain key SCIM_AUTH_TOKEN)
     secretRef: ""
 api:
+  dex:
+    grpc:
+      # -- Dex GRPC API host
+      host: ""
+      # -- Dex GRPC API port
+      port: 5557
   debug:
     # -- Toggle whether to enable debug logs by setting the GODEBUG=http2debug=2
     enableHttp2Logs: false


### PR DESCRIPTION
Checklist:

* [ ] Any new values are backwards compatible and/or have sensible default.
* [ ] I have signed off all my commits as required by [DCO](https://github.com/kubeshop/testkube-cloud-charts/blob/master/community/CONTRIBUTING.md).
* [ ] My CI is green.

<!-- Changes are automatically published when merged to `main`. They are not published on branches. -->