### PR TITLE
fix: trigger chart release on workflow dispatch

### DIFF
--- a/.github/workflows/chart-release.yaml
+++ b/.github/workflows/chart-release.yaml
@@ -1,16 +1,7 @@
 name: Release Helm charts
 
 on:
-  workflow_run:
-    workflows: [ "Update application version on dispatch" ]
-    types:
-      - completed
-  push:
-    branches:
-      - main
-    paths-ignore:
-      - "**/.argocd-source-*"
-      - ".github/**"
+  workflow_dispatch:
 
 jobs:
   release-helm-charts:


### PR DESCRIPTION
**Background:**

Wito has disabled this workflow as he is working on a new release process, but I need to create a new release.

Checklist:

* [ ] Any new values are backwards compatible and/or have sensible default.
* [ ] I have signed off all my commits as required by [DCO](https://github.com/kubeshop/testkube-cloud-charts/blob/master/community/CONTRIBUTING.md).
* [ ] My CI is green.

<!-- Changes are automatically published when merged to `main`. They are not published on branches. -->