### PR TITLE
chore: add unified versioning

### DIFF
--- a/charts/testkube-ai-service/templates/_helpers.tpl
+++ b/charts/testkube-ai-service/templates/_helpers.tpl
@@ -82,19 +82,24 @@ Define AI API image
 {{- $registryName := default "docker.io" .Values.image.registry -}}
 {{- $repositoryName := .Values.image.repository -}}
 {{- $tag := default .Chart.AppVersion .Values.image.tag | toString -}}
+{{- $tagSuffix := .Values.image.tagSuffix -}}
 {{- $separator := ":" -}}
 {{- if .Values.image.digest }}
     {{- $separator = "@" -}}
     {{- $tag = .Values.image.digest | toString -}}
 {{- end -}}
 {{- if .Values.global }}
+    {{- if .Values.global.testkubeVersion -}}
+        {{- $tag = .Values.global.testkubeVersion | toString -}}
+    {{- end -}}
+
     {{- if .Values.global.imageRegistry }}
-        {{- printf "%s/%s%s%s" .Values.global.imageRegistry $repositoryName $separator $tag -}}
+        {{- printf "%s/%s%s%s%s" .Values.global.imageRegistry $repositoryName $separator $tag $tagSuffix -}}
     {{- else -}}
-        {{- printf "%s/%s%s%s" $registryName $repositoryName $separator $tag -}}
+        {{- printf "%s/%s%s%s%s" $registryName $repositoryName $separator $tag $tagSuffix -}}
     {{- end -}}
 {{- else -}}
-    {{- printf "%s/%s%s%s" $registryName $repositoryName $separator $tag -}}
+    {{- printf "%s/%s%s%s%s" $registryName $repositoryName $separator $tag $tagSuffix -}}
 {{- end -}}
 {{- end -}}
 

--- a/charts/testkube-ai-service/values.yaml
+++ b/charts/testkube-ai-service/values.yaml
@@ -41,6 +41,7 @@ image:
   repository: kubeshop/testkube-ai-copilot
   pullPolicy: IfNotPresent
   tag: "2.4.2"
+  tagSuffix: ""
 imagePullSecrets: []
 nameOverride: ""
 fullnameOverride: ""

--- a/charts/testkube-cloud-api/templates/_helpers.tpl
+++ b/charts/testkube-cloud-api/templates/_helpers.tpl
@@ -132,19 +132,24 @@ Define API image
 {{- $registryName := default "docker.io" .Values.image.registry -}}
 {{- $repositoryName := .Values.image.repository -}}
 {{- $tag := default .Chart.AppVersion .Values.image.tag | toString -}}
+{{- $tagSuffix := .Values.image.tagSuffix -}}
 {{- $separator := ":" -}}
 {{- if .Values.image.digest }}
     {{- $separator = "@" -}}
     {{- $tag = .Values.image.digest | toString -}}
 {{- end -}}
 {{- if .Values.global }}
+    {{- if .Values.global.testkubeVersion -}}
+        {{- $tag = .Values.global.testkubeVersion | toString -}}
+    {{- end -}}
+
     {{- if .Values.global.imageRegistry }}
-        {{- printf "%s/%s%s%s" .Values.global.imageRegistry $repositoryName $separator $tag -}}
+        {{- printf "%s/%s%s%s%s" .Values.global.imageRegistry $repositoryName $separator $tag $tagSuffix -}}
     {{- else -}}
-        {{- printf "%s/%s%s%s" $registryName $repositoryName $separator $tag -}}
+        {{- printf "%s/%s%s%s%s" $registryName $repositoryName $separator $tag $tagSuffix -}}
     {{- end -}}
 {{- else -}}
-    {{- printf "%s/%s%s%s" $registryName $repositoryName $separator $tag -}}
+    {{- printf "%s/%s%s%s%s" $registryName $repositoryName $separator $tag $tagSuffix -}}
 {{- end -}}
 {{- end -}}
 
@@ -155,19 +160,24 @@ Define Migration image
 {{- $registryName := default "docker.io" .Values.migrationImage.registry -}}
 {{- $repositoryName := .Values.migrationImage.repository -}}
 {{- $tag := default .Chart.AppVersion .Values.migrationImage.tag | toString -}}
+{{- $tagSuffix := .Values.image.tagSuffix -}}
 {{- $separator := ":" -}}
 {{- if .Values.migrationImage.digest }}
     {{- $separator = "@" -}}
     {{- $tag = .Values.migrationImage.digest | toString -}}
 {{- end -}}
 {{- if .Values.global }}
+    {{- if .Values.global.testkubeVersion -}}
+        {{- $tag = .Values.global.testkubeVersion | toString -}}
+    {{- end -}}
+
     {{- if .Values.global.imageRegistry }}
-        {{- printf "%s/%s%s%s" .Values.global.imageRegistry $repositoryName $separator $tag -}}
+        {{- printf "%s/%s%s%s%s" .Values.global.imageRegistry $repositoryName $separator $tag $tagSuffix -}}
     {{- else -}}
-        {{- printf "%s/%s%s%s" $registryName $repositoryName $separator $tag -}}
+        {{- printf "%s/%s%s%s%s" $registryName $repositoryName $separator $tag $tagSuffix -}}
     {{- end -}}
 {{- else -}}
-    {{- printf "%s/%s%s%s" $registryName $repositoryName $separator $tag -}}
+    {{- printf "%s/%s%s%s%s" $registryName $repositoryName $separator $tag $tagSuffix -}}
 {{- end -}}
 {{- end -}}
 

--- a/charts/testkube-cloud-api/values.yaml
+++ b/charts/testkube-cloud-api/values.yaml
@@ -127,12 +127,14 @@ image:
   repository: kubeshop/testkube-enterprise-api
   pullPolicy: IfNotPresent
   tag: "1.12.0"
+  tagSuffix: ""
 migrationImage:
   # -- If defined, it will prepend the registry to the image name, if not, default docker.io will be prepended
   registry: ""
   repository: kubeshop/testkube-migration
   pullPolicy: IfNotPresent
   tag: "1.12.0"
+  tagSuffix: ""
 imagePullSecrets: []
 nameOverride: ""
 fullnameOverride: ""

--- a/charts/testkube-cloud-ui/templates/_helpers.tpl
+++ b/charts/testkube-cloud-ui/templates/_helpers.tpl
@@ -83,19 +83,24 @@ Define image
 {{- $registryName := default "docker.io" .Values.image.registry -}}
 {{- $repositoryName := .Values.image.repository -}}
 {{- $tag := default .Chart.AppVersion .Values.image.tag | toString -}}
+{{- $tagSuffix := .Values.image.tagSuffix -}}
 {{- $separator := ":" -}}
 {{- if .Values.image.digest }}
     {{- $separator = "@" -}}
     {{- $tag = .Values.image.digest | toString -}}
 {{- end -}}
 {{- if .Values.global }}
+    {{- if .Values.global.testkubeVersion -}}
+        {{- $tag = .Values.global.testkubeVersion | toString -}}
+    {{- end -}}
+
     {{- if .Values.global.imageRegistry }}
-        {{- printf "%s/%s%s%s" .Values.global.imageRegistry $repositoryName $separator $tag -}}
+        {{- printf "%s/%s%s%s%s" .Values.global.imageRegistry $repositoryName $separator $tag $tagSuffix -}}
     {{- else -}}
-        {{- printf "%s/%s%s%s" $registryName $repositoryName $separator $tag -}}
+        {{- printf "%s/%s%s%s%s" $registryName $repositoryName $separator $tag $tagSuffix -}}
     {{- end -}}
 {{- else -}}
-    {{- printf "%s/%s%s%s" $registryName $repositoryName $separator $tag -}}
+    {{- printf "%s/%s%s%s%s" $registryName $repositoryName $separator $tag $tagSuffix -}}
 {{- end -}}
 {{- end -}}
 

--- a/charts/testkube-cloud-ui/values.yaml
+++ b/charts/testkube-cloud-ui/values.yaml
@@ -55,6 +55,7 @@ image:
   pullPolicy: IfNotPresent
   # Overrides the image tag whose default is the chart appVersion.
   tag: "2.12.6"
+  tagSuffix: ""
 imagePullSecrets: []
 nameOverride: ""
 fullnameOverride: ""

--- a/charts/testkube-enterprise/values.yaml
+++ b/charts/testkube-enterprise/values.yaml
@@ -3,6 +3,7 @@
 # Declare variables to be passed into your templates.
 
 global:
+  testkubeVersion: "1.12.0"
   # -- Run Testkube in enterprise mode (enables enterprise features)
   enterpriseMode: true
   # -- Toggle whether to enable offline license activation in Enterprise mode
@@ -30,7 +31,7 @@ global:
   # -- AI API subdomain which get prepended to the domain
   aiApiSubdomain: "ai"
   # -- TLS certificate provider. Set to "cert-manager" for integration with cert-manager or leave empty for other methods
-  certificateProvider: "cert-manager"
+  certificateProvider: ""
   certManager:
     # -- Certificate Issuer ref (only used if `provider` is set to `cert-manager`)
     issuerRef: ""
@@ -473,9 +474,10 @@ testkube-cloud-ui:
     FEATURE_MULTI_AGENT: true
   image:
     # -- If defined, it will prepend the registry to the image name, if not, default docker.io will be prepended
-    registry: ""
-    repository: kubeshop/testkube-enterprise-ui
+    registry: registry.depot.dev
+    repository: 8m4mpphf9g
     tag: 2.12.6
+    tagSuffix: -cloud-ui
   # -- Pod Security Context
   podSecurityContext: {}
   # fsGroup: 2000
@@ -932,7 +934,7 @@ dex:
     #    name: Testkube Cloud - localdev
     #    redirectURIs:
     #      - http://localhost:8090/auth/callback
-    #      - http://localhost:38090/auth/callback    
+    #      - http://localhost:38090/auth/callback
     #    secret: some-secret
     # -- Additional config which will be appended to the config like `staticClients`, `staticPasswords ,`connectors`...
     additionalConfig: ""

--- a/charts/testkube-logs-service/templates/_helpers.tpl
+++ b/charts/testkube-logs-service/templates/_helpers.tpl
@@ -99,19 +99,24 @@ Define image
 {{- $registryName := default "docker.io" .Values.image.registry -}}
 {{- $repositoryName := .Values.image.repository -}}
 {{- $tag := default .Chart.AppVersion .Values.image.tag | toString -}}
+{{- $tagSuffix := .Values.image.tagSuffix -}}
 {{- $separator := ":" -}}
 {{- if .Values.image.digest }}
     {{- $separator = "@" -}}
     {{- $tag = .Values.image.digest | toString -}}
 {{- end -}}
 {{- if .Values.global }}
+    {{- if .Values.global.testkubeVersion -}}
+        {{- $tag = .Values.global.testkubeVersion | toString -}}
+    {{- end -}}
+
     {{- if .Values.global.imageRegistry }}
-        {{- printf "%s/%s%s%s" .Values.global.imageRegistry $repositoryName $separator $tag -}}
+        {{- printf "%s/%s%s%s%s" .Values.global.imageRegistry $repositoryName $separator $tag $tagSuffix -}}
     {{- else -}}
-        {{- printf "%s/%s%s%s" $registryName $repositoryName $separator $tag -}}
+        {{- printf "%s/%s%s%s%s" $registryName $repositoryName $separator $tag $tagSuffix -}}
     {{- end -}}
 {{- else -}}
-    {{- printf "%s/%s%s%s" $registryName $repositoryName $separator $tag -}}
+    {{- printf "%s/%s%s%s%s" $registryName $repositoryName $separator $tag $tagSuffix -}}
 {{- end -}}
 {{- end -}}
 

--- a/charts/testkube-logs-service/values.yaml
+++ b/charts/testkube-logs-service/values.yaml
@@ -32,6 +32,7 @@ image:
   repository: kubeshop/testkube-log-service
   pullPolicy: IfNotPresent
   tag: "1.6.7"
+  tagSuffix: ""
 imagePullSecrets: []
 nameOverride: ""
 fullnameOverride: "logs-service"

--- a/charts/testkube-worker-service/templates/_helpers.tpl
+++ b/charts/testkube-worker-service/templates/_helpers.tpl
@@ -128,19 +128,24 @@ Define image
 {{- $registryName := default "docker.io" .Values.image.registry -}}
 {{- $repositoryName := .Values.image.repository -}}
 {{- $tag := default .Chart.AppVersion .Values.image.tag | toString -}}
+{{- $tagSuffix := .Values.image.tagSuffix -}}
 {{- $separator := ":" -}}
 {{- if .Values.image.digest }}
     {{- $separator = "@" -}}
     {{- $tag = .Values.image.digest | toString -}}
 {{- end -}}
 {{- if .Values.global }}
+    {{- if .Values.global.testkubeVersion -}}
+        {{- $tag = .Values.global.testkubeVersion | toString -}}
+    {{- end -}}
+
     {{- if .Values.global.imageRegistry }}
-        {{- printf "%s/%s%s%s" .Values.global.imageRegistry $repositoryName $separator $tag -}}
+        {{- printf "%s/%s%s%s%s" .Values.global.imageRegistry $repositoryName $separator $tag $tagSuffix -}}
     {{- else -}}
-        {{- printf "%s/%s%s%s" $registryName $repositoryName $separator $tag -}}
+        {{- printf "%s/%s%s%s%s" $registryName $repositoryName $separator $tag $tagSuffix -}}
     {{- end -}}
 {{- else -}}
-    {{- printf "%s/%s%s%s" $registryName $repositoryName $separator $tag -}}
+    {{- printf "%s/%s%s%s%s" $registryName $repositoryName $separator $tag $tagSuffix -}}
 {{- end -}}
 {{- end -}}
 


### PR DESCRIPTION
Support unified versioning inspired by [GitLab versioning](https://docs.gitlab.com/charts/charts/globals/#gitlab-version)

```
global:
  testkubeVersion: 1.10.0 
```

This will set the image version for the dashboard, api, workers, ai agent and migration.

It also adds support for tag suffixes. This opens the door for conveniently using ephemeral images using Docker bake.

```
global:
  testkubeVersion: branch-name
testkube-cloud-api:
  image:
    registry: registry.depot.dev
    repository: 8m4mpxxxx
    postfix: -cloud-api
testkube-cloud-ui:
  image:
    registry: registry.depot.dev
    repository: 8m4mpxxxx
    tagSuffix: -cloud-ui
```